### PR TITLE
Migrate to New Security Model

### DIFF
--- a/charts/compute/templates/server/deployment.yaml
+++ b/charts/compute/templates/server/deployment.yaml
@@ -23,6 +23,8 @@ spec:
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         {{- include "unikorn.identity.flags" . | nindent 8 }}
         {{- include "unikorn.region.flags" . | nindent 8 }}
+        - --client-certificate-namespace={{ .Release.Namespace }}
+        - --client-certificate-name=unikorn-compute-client-certificate
         ports:
         - name: http
           containerPort: 6080

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/unikorn-cloud/core v0.1.77
-	github.com/unikorn-cloud/identity v0.2.42
-	github.com/unikorn-cloud/region v0.1.44
+	github.com/unikorn-cloud/identity v0.2.44
+	github.com/unikorn-cloud/region v0.1.45
 	go.opentelemetry.io/otel/sdk v1.31.0
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
+	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	sigs.k8s.io/controller-runtime v0.19.0
 )
 
@@ -88,7 +89,6 @@ require (
 	k8s.io/client-go v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241009091222-67ed5848f094 // indirect
-	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,10 +137,10 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v0.1.77 h1:DHxIOuS5RAZylzxHF/kUt955TdmE5kJiY/Z2yqC0/e0=
 github.com/unikorn-cloud/core v0.1.77/go.mod h1:S9AF4PwTQljImb9w0P2jKjzRe8fLM+rx+ZbxrAHw/yE=
-github.com/unikorn-cloud/identity v0.2.42 h1:9amEcydDq23RZYO4rTtxOhVgw/BH1mdXQgq0fWT+RM0=
-github.com/unikorn-cloud/identity v0.2.42/go.mod h1:JMbS6iTYzt0OVt5AkqZys3WVnpLabGvUl8kGWcxzFZI=
-github.com/unikorn-cloud/region v0.1.44 h1:GJnUHFBkxnOAssHd7NBXY9Zpva6lB5ozKPesHnORVzo=
-github.com/unikorn-cloud/region v0.1.44/go.mod h1:N5wS4Js49JR5WARnRwzeVXRL//M+WVKZBAiqQVA7Yao=
+github.com/unikorn-cloud/identity v0.2.44 h1:tXV/qsJ77Dkx8ba8gnBFXHWUgBNsJ2oo/5TjnyhkH7U=
+github.com/unikorn-cloud/identity v0.2.44/go.mod h1:JMbS6iTYzt0OVt5AkqZys3WVnpLabGvUl8kGWcxzFZI=
+github.com/unikorn-cloud/region v0.1.45 h1:qpUwB+s/SEZNHZqwHTYovtWUVdJB2AKEl06NbiIwnOw=
+github.com/unikorn-cloud/region v0.1.45/go.mod h1:QqWLEfB8bNRIUAU7h5JjkQsjyJdTV+2ltDYksRjKMds=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -112,14 +112,14 @@ func (p *Provisioner) getRegionClient(ctx context.Context, traceName string) (co
 
 	tokenIssuer := identityclient.NewTokenIssuer(cli, p.options.identityOptions, &p.options.clientOptions, constants.Application, constants.Version)
 
-	ctx, err = tokenIssuer.Context(ctx, traceName)
+	token, err := tokenIssuer.Issue(ctx, traceName)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	getter := regionclient.New(cli, p.options.regionOptions, &p.options.clientOptions)
 
-	client, err := getter.Client(ctx)
+	client, err := getter.Client(ctx, token)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -152,9 +152,13 @@ func (s *Server) GetServer(client client.Client) (*http.Server, error) {
 		},
 	}
 
+	// NOTE: any clients that are used, must issue new tokens as this service to
+	// prevent the user having to be granted excessive privilege.
+	issuer := identityclient.NewTokenIssuer(client, s.IdentityOptions, &s.ClientOptions, constants.Application, constants.Version)
+
 	region := regionclient.New(client, s.RegionOptions, &s.ClientOptions)
 
-	handlerInterface, err := handler.New(client, s.Options.Namespace, &s.HandlerOptions, region)
+	handlerInterface, err := handler.New(client, s.Options.Namespace, &s.HandlerOptions, issuer, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Having access to the compute service should not require direct access to the region service endpoints.  Move things so privilege is escalated in the controller/API and not granted to the user directly.