### PR TITLE
Protect Resources with CEL

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: v0.1.5-rc1
-appVersion: v0.1.5-rc1
+version: v0.1.5-rc2
+appVersion: v0.1.5-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/charts/compute/templates/validatingadmissionpolicies/clusterresources.yaml
+++ b/charts/compute/templates/validatingadmissionpolicies/clusterresources.yaml
@@ -1,0 +1,39 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: cluster-resources.compute.unikorn-cloud.org
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:
+      - compute.unikorn-cloud.org
+      apiVersions:
+      - '*'
+      resources:
+      - computeclusters
+      operations:
+      - CREATE
+      - UPDATE
+  validations:
+  - expression: "object.metadata.?labels[?'unikorn-cloud.org/name'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/name label
+  - expression: "object.metadata.?labels[?'unikorn-cloud.org/organization'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/organization label
+  - expression: "object.metadata.?labels[?'unikorn-cloud.org/project'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/project label
+  - expression: "object.metadata.?annotations[?'unikorn-cloud.org/identity-id'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/identity-id annotations
+  - expression: "object.metadata.?annotations[?'unikorn-cloud.org/physical-network-id'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/physical-network-id annotations
+  - expression: "object.metadata.?annotations[?'unikorn-cloud.org/allocation-id'].orValue('') != ''"
+    message: Resource must contain a unikorn-cloud.org/allocation-id annotation
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: cluster-resources.compute.unikorn-cloud.org
+spec:
+  policyName: cluster-resources.compute.unikorn-cloud.org
+  validationActions:
+  - Deny


### PR DESCRIPTION
Ensure labels and annotations that are expected to exist do.  We could also extend this to make them immutable, but I suspect if we need to perform a migration or some form of emergency patching this would be an impediment more than a benfit at the operations level.  One for the future though when things get more stable and mature.