### PR TITLE
Remove API Pointers

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: v0.1.7-rc1
-appVersion: v0.1.7-rc1
+version: v0.1.7-rc2
+appVersion: v0.1.7-rc2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.6
 	github.com/spjmurray/go-util v0.1.3
-	github.com/unikorn-cloud/core v0.1.95-rc1
+	github.com/unikorn-cloud/core v0.1.95-rc2
 	github.com/unikorn-cloud/identity v0.2.63-rc1
 	github.com/unikorn-cloud/region v0.1.54-rc1
 	go.opentelemetry.io/otel/sdk v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v0.1.95-rc1 h1:guNDD9MOsHwEbyEAyqtGOc0umyQ586OYHcvh7jHXeyg=
-github.com/unikorn-cloud/core v0.1.95-rc1/go.mod h1:OdZlqXlkO0EFaThARFYRctKAtsVKimhSZid72OaC43Y=
+github.com/unikorn-cloud/core v0.1.95-rc2 h1:l1zNxPTFqrRIuKPXzvsCDsc/5B6hquF7GPjHJGviIUA=
+github.com/unikorn-cloud/core v0.1.95-rc2/go.mod h1:OdZlqXlkO0EFaThARFYRctKAtsVKimhSZid72OaC43Y=
 github.com/unikorn-cloud/identity v0.2.63-rc1 h1:RsZ+pxOQ8s77usWfsZtBKdHDyQZc+gcQAuEyGZX37NY=
 github.com/unikorn-cloud/identity v0.2.63-rc1/go.mod h1:ba6iPmqnjOpTT4D7Hxix0IHtPZamktFIgziQ1SckMUI=
 github.com/unikorn-cloud/region v0.1.54-rc1 h1:LE9vmhTpASmmtFtFKE72JhL0s5sSSU7b+L3VkFZvA+Y=

--- a/pkg/provisioners/managers/cluster/server.go
+++ b/pkg/provisioners/managers/cluster/server.go
@@ -143,9 +143,9 @@ func (p *Provisioner) createServer(ctx context.Context, client regionapi.ClientW
 			Tags:        p.tags(pool),
 		},
 		Spec: regionapi.ServerWriteSpec{
-			FlavorId: *pool.FlavorID,
+			FlavorId: pool.FlavorID,
 			Image: regionapi.ServerImage{
-				Id: *pool.ImageID,
+				Id: pool.ImageID,
 			},
 			Networks: regionapi.ServerNetworkList{
 				regionapi.ServerNetwork{
@@ -189,7 +189,7 @@ func (p *Provisioner) serverReconciliationList(provisioned computeprovisioners.P
 	// Things that should exist...
 	desiredNames := set.New[string]()
 
-	for i := range *desired.Replicas {
+	for i := range desired.Replicas {
 		desiredNames.Add(serverName(desired, i))
 	}
 

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -148,12 +148,12 @@ func (c *Client) generateAllocations(ctx context.Context, organizationID string,
 
 	// NOTE: the control plane is "free".
 	for _, pool := range resource.Spec.WorkloadPools.Pools {
-		serversMinimum := *pool.Replicas
+		serversMinimum := pool.Replicas
 
 		serversCommitted += serversMinimum
 
 		flavorByID := func(f regionapi.Flavor) bool {
-			return f.Metadata.Id == *pool.FlavorID
+			return f.Metadata.Id == pool.FlavorID
 		}
 
 		index := slices.IndexFunc(flavors, flavorByID)

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -34,8 +34,6 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/middleware/authorization"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -77,8 +75,8 @@ func newGenerator(client client.Client, options *Options, region regionapi.Clien
 // convertMachine converts from a custom resource into the API definition.
 func (g *generator) convertMachine(in *unikornv1.ComputeWorkloadPoolSpec) *openapi.MachinePool {
 	return &openapi.MachinePool{
-		Replicas:            *in.Replicas,
-		FlavorId:            *in.FlavorID,
+		Replicas:            in.Replicas,
+		FlavorId:            in.FlavorID,
 		PublicIPAllocation:  convertPublicIPAllocation(in.PublicIPAllocation),
 		Firewall:            convertFirewallRules(in.Firewall),
 		Image:               convertImage(in),
@@ -108,7 +106,7 @@ func convertAllowedAddressPairs(in []unikornv1.ComputeWorkloadPoolAddressPair) *
 func convertImage(in *unikornv1.ComputeWorkloadPoolSpec) openapi.ComputeImage {
 	if in.ImageSelector == nil {
 		return openapi.ComputeImage{
-			Id: in.ImageID,
+			Id: &in.ImageID,
 		}
 	}
 
@@ -389,7 +387,7 @@ func (g *generator) generateNetwork() *unikornv1core.NetworkGeneric {
 	dnsNameservers := g.options.DNSNameservers
 
 	network := &unikornv1core.NetworkGeneric{
-		NodeNetwork:    &unikornv1core.IPv4Prefix{IPNet: nodeNetwork},
+		NodeNetwork:    unikornv1core.IPv4Prefix{IPNet: nodeNetwork},
 		DNSNameservers: unikornv1core.IPv4AddressSliceFromIPSlice(dnsNameservers),
 	}
 
@@ -404,9 +402,9 @@ func (g *generator) generateMachineGeneric(ctx context.Context, request *openapi
 	}
 
 	machine := &unikornv1core.MachineGeneric{
-		Replicas: &m.Replicas,
-		ImageID:  ptr.To(image.Metadata.Id),
-		FlavorID: &flavor.Metadata.Id,
+		Replicas: m.Replicas,
+		ImageID:  image.Metadata.Id,
+		FlavorID: flavor.Metadata.Id,
 	}
 
 	return machine, nil


### PR DESCRIPTION
There are quite a lot of places where we use pointers but the value is required.  We should remove these so that the code that relies on these types doesn't have to dereference, and I don't get asked questions about nil pointer checks.