### PR TITLE
Add Client Caching

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: v0.1.7
-appVersion: v0.1.7
+version: v0.1.8-rc1
+appVersion: v0.1.8-rc1
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/spjmurray/go-util v0.1.3
 	github.com/unikorn-cloud/core v0.1.96-rc1
 	github.com/unikorn-cloud/identity v0.2.63
-	github.com/unikorn-cloud/region v0.1.54
+	github.com/unikorn-cloud/region v0.1.55-rc1
 	go.opentelemetry.io/otel/sdk v1.35.0
 	k8s.io/api v0.33.0
 	k8s.io/apimachinery v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -143,8 +143,8 @@ github.com/unikorn-cloud/core v0.1.96-rc1 h1:TgSMyHhUWYmWgLXiTWNUsroO3F2LtTJ/k+n
 github.com/unikorn-cloud/core v0.1.96-rc1/go.mod h1:stInT6j9sM9KzDHgNxBtmrdDIAxQuIZI1/TCGo0jNK8=
 github.com/unikorn-cloud/identity v0.2.63 h1:cG3Aa3LmweqOwNtOeq9W29/aoJ4wY0uiulLNzWwn7TY=
 github.com/unikorn-cloud/identity v0.2.63/go.mod h1:xuOIyB4wDAz4+kJfZk2q+8MqGj+9IhVbd0Q38iqBY24=
-github.com/unikorn-cloud/region v0.1.54 h1:orGCMLIMUmSWLOlBBha6q5SgXKAlzFqQJRVhneD4/so=
-github.com/unikorn-cloud/region v0.1.54/go.mod h1:wLNamsGnGIpGTQYFsjyuvelLu5LdtKiniZu0rXu8oUo=
+github.com/unikorn-cloud/region v0.1.55-rc1 h1:rnEqKMthOboBi1Coi+FQ/IfAU6jYbYfO9yP+Iaselss=
+github.com/unikorn-cloud/region v0.1.55-rc1/go.mod h1:wLNamsGnGIpGTQYFsjyuvelLu5LdtKiniZu0rXu8oUo=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Caching the data is all well and good, but we need to cache the client too to avoid creating a new one for listing images and flavors during cluster creation.