### PR TITLE
test(compute): add explicit instance delete lifecycle test

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -180,7 +180,7 @@ func (c *APIClient) GetInstance(ctx context.Context, instanceID string) (openapi
 
 		return instance, nil
 	case http.StatusNotFound:
-		return openapi.InstanceRead{}, fmt.Errorf("instance '%s' not found (status: %d)", instanceID, resp.StatusCode)
+		return openapi.InstanceRead{}, fmt.Errorf("instance '%s': %w", instanceID, coreclient.ErrResourceNotFound)
 	case http.StatusForbidden:
 		return openapi.InstanceRead{}, fmt.Errorf("instance '%s' access denied (status: %d)", instanceID, resp.StatusCode)
 	default:
@@ -227,6 +227,20 @@ func (c *APIClient) UpdateInstance(ctx context.Context, instanceID string, reque
 	}
 
 	return instance, nil
+}
+
+// DeleteInstanceWithStatus deletes an instance and returns the raw HTTP status code,
+// allowing callers to assert the exact response (e.g. 202 vs 404).
+func (c *APIClient) DeleteInstanceWithStatus(ctx context.Context, instanceID string) (int, error) {
+	path := c.endpoints.DeleteInstance(instanceID)
+
+	//nolint:bodyclose // response body is closed in DoRequest
+	resp, _, err := c.DoRequest(ctx, http.MethodDelete, path, nil, 0)
+	if err != nil {
+		return 0, fmt.Errorf("deleting instance: %w", err)
+	}
+
+	return resp.StatusCode, nil
 }
 
 // GetInstanceConsoleOutput retrieves console output for an instance.

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -21,12 +21,14 @@ limitations under the License.
 package suites
 
 import (
+	"net/http"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	coreclient "github.com/unikorn-cloud/core/pkg/testing/client"
 
 	"github.com/unikorn-cloud/compute/pkg/openapi"
 	"github.com/unikorn-cloud/compute/test/api"
@@ -104,6 +106,33 @@ var _ = Describe("Instance Operations", func() {
 					"updated description should persist in subsequent GET")
 
 				GinkgoWriter.Printf("Instance %s description updated and verified via GET\n", instance.Metadata.Id)
+			})
+		})
+	})
+
+	Context("When deleting an instance", func() {
+		Describe("Given a provisioned instance", func() {
+			var instanceID string
+
+			BeforeEach(func() {
+				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
+					api.NewInstancePayload().Build())
+				instanceID = iID
+				GinkgoWriter.Printf("Using instance %s for delete lifecycle test\n", instanceID)
+			})
+
+			It("should successfully delete and return not found on subsequent get", func() {
+				status, err := client.DeleteInstanceWithStatus(ctx, instanceID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(status).To(Equal(http.StatusAccepted),
+					"DELETE should return 202 Accepted, got %d", status)
+
+				Eventually(func() error {
+					_, err := client.GetInstance(ctx, instanceID)
+					return err
+				}).WithTimeout(config.TestTimeout).WithPolling(5 * time.Second).Should(MatchError(coreclient.ErrResourceNotFound))
+
+				GinkgoWriter.Printf("Instance %s confirmed deleted\n", instanceID)
 			})
 		})
 	})


### PR DESCRIPTION
Closes INST-860

Adds an explicit integration test for the instance delete lifecycle. The existing `DeferCleanup` in `CreateInstanceWithCleanup` accepts both 202 and 404 silently, so the exact HTTP status on a fresh delete was never directly asserted.

## Changes

- `test/api/api_client.go` — add `DeleteInstanceWithStatus` returning `(int, error)` for raw status code access
- `test/api/suites/instance_operations_test.go` — new `Context("When deleting an instance explicitly")` that asserts DELETE returns 202, polls until GET returns 404, then confirms the 404 explicitly

## Tested

Ran against dev (`nks-dev.glo1.nscale.com`) — passed in 12s.