### PR TITLE
test(compute): add ListInstances integration test

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -119,6 +119,21 @@ func (c *APIClient) ListImages(ctx context.Context, orgID, regionID string) (reg
 	return coreclient.ListResource[regionopenapi.Image](ctx, c.APIClient, path, config)
 }
 
+// ListInstances returns all instances visible to the caller, filtered by org and project.
+func (c *APIClient) ListInstances(ctx context.Context, orgID, projectID string) (openapi.InstancesRead, error) {
+	path := c.endpoints.ListInstances(orgID, projectID)
+
+	config := coreclient.ResponseHandlerConfig{
+		ResourceType:   "instances",
+		ResourceID:     orgID,
+		ResourceIDType: "organization",
+		AllowForbidden: true,
+		AllowNotFound:  true,
+	}
+
+	return coreclient.ListResource[openapi.InstanceRead](ctx, c.APIClient, path, config)
+}
+
 // CreateInstance creates a new instance.
 func (c *APIClient) CreateInstance(ctx context.Context, payload openapi.InstanceCreate) (openapi.InstanceRead, error) {
 	path := c.endpoints.CreateInstance()

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -47,6 +47,11 @@ func (e *Endpoints) ListImages(orgID, regionID string) string {
 }
 
 // Instance management endpoints (V2 API).
+func (e *Endpoints) ListInstances(orgID, projectID string) string {
+	return fmt.Sprintf("/api/v2/instances?organizationID=%s&projectID=%s",
+		url.QueryEscape(orgID), url.QueryEscape(projectID))
+}
+
 func (e *Endpoints) CreateInstance() string {
 	return "/api/v2/instances"
 }

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -26,6 +26,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+
 	"github.com/unikorn-cloud/compute/pkg/openapi"
 	"github.com/unikorn-cloud/compute/test/api"
 )
@@ -33,6 +35,41 @@ import (
 const nonExistentInstanceID = "non-existent-instance-12345"
 
 var _ = Describe("Instance Operations", func() {
+	Context("When listing instances", func() {
+		Describe("Given a provisioned instance", func() {
+			var instanceID string
+
+			BeforeEach(func() {
+				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
+					api.NewInstancePayload().Build())
+				instanceID = iID
+				GinkgoWriter.Printf("Using instance %s for list test\n", instanceID)
+			})
+
+			It("should return the provisioned instance in the list", func() {
+				instances, err := client.ListInstances(ctx, config.OrgID, config.ProjectID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(instances).NotTo(BeEmpty())
+
+				instanceIDs := make([]string, len(instances))
+				for i, inst := range instances {
+					instanceIDs[i] = inst.Metadata.Id
+				}
+				Expect(instanceIDs).To(ContainElement(instanceID),
+					"provisioned instance %s should appear in list", instanceID)
+
+				for _, inst := range instances {
+					if inst.Metadata.Id == instanceID {
+						Expect(inst.Metadata.ProvisioningStatus).To(Equal(coreapi.ResourceProvisioningStatusProvisioned))
+						break
+					}
+				}
+
+				GinkgoWriter.Printf("Found instance %s in list with status provisioned\n", instanceID)
+			})
+		})
+	})
+
 	Context("When creating an instance", func() {
 		Context("from a custom image", func() {
 			var (


### PR DESCRIPTION
Adds `ListInstances` to the typed API client and an integration test that verifies a provisioned instance appears in the list with `provisioned` status.

Closes INST-859.