### PR TITLE
test(compute): add UpdateInstance integration test

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -206,6 +206,29 @@ func (c *APIClient) DeleteInstance(ctx context.Context, instanceID string) error
 	return nil
 }
 
+// UpdateInstance updates an instance via PUT and returns the updated resource.
+func (c *APIClient) UpdateInstance(ctx context.Context, instanceID string, request openapi.InstanceUpdate) (openapi.InstanceRead, error) {
+	path := c.endpoints.UpdateInstance(instanceID)
+
+	reqBody, err := json.Marshal(request)
+	if err != nil {
+		return openapi.InstanceRead{}, fmt.Errorf("marshaling instance update request: %w", err)
+	}
+
+	//nolint:bodyclose // response body is closed in DoRequest
+	_, respBody, err := c.DoRequest(ctx, http.MethodPut, path, bytes.NewReader(reqBody), http.StatusAccepted)
+	if err != nil {
+		return openapi.InstanceRead{}, fmt.Errorf("updating instance: %w", err)
+	}
+
+	var instance openapi.InstanceRead
+	if err := json.Unmarshal(respBody, &instance); err != nil {
+		return openapi.InstanceRead{}, fmt.Errorf("unmarshaling instance response: %w", err)
+	}
+
+	return instance, nil
+}
+
 // GetInstanceConsoleOutput retrieves console output for an instance.
 func (c *APIClient) GetInstanceConsoleOutput(ctx context.Context, instanceID string, length *int) (*regionopenapi.ConsoleOutputResponse, error) {
 	path := c.endpoints.GetInstanceConsoleOutput(instanceID)

--- a/test/api/endpoints.go
+++ b/test/api/endpoints.go
@@ -64,6 +64,10 @@ func (e *Endpoints) DeleteInstance(instanceID string) string {
 	return fmt.Sprintf("/api/v2/instances/%s", url.PathEscape(instanceID))
 }
 
+func (e *Endpoints) UpdateInstance(instanceID string) string {
+	return fmt.Sprintf("/api/v2/instances/%s", url.PathEscape(instanceID))
+}
+
 func (e *Endpoints) GetInstanceConsoleOutput(instanceID string) string {
 	return fmt.Sprintf("/api/v2/instances/%s/consoleoutput", url.PathEscape(instanceID))
 }

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -70,6 +70,44 @@ var _ = Describe("Instance Operations", func() {
 		})
 	})
 
+	Context("When updating an instance", func() {
+		Describe("Given a provisioned instance", func() {
+			var instance openapi.InstanceRead
+
+			BeforeEach(func() {
+				var iID string
+				instance, iID = api.CreateInstanceWithCleanup(client, ctx, config,
+					api.NewInstancePayload().Build())
+				GinkgoWriter.Printf("Using instance %s for update test\n", iID)
+			})
+
+			It("should update the instance description and persist it", func() {
+				updatedDescription := "updated description for test"
+
+				updateReq := openapi.InstanceUpdate{
+					Metadata: coreapi.ResourceWriteMetadata{
+						Name:        instance.Metadata.Name,
+						Description: &updatedDescription,
+					},
+					Spec: instance.Spec,
+				}
+
+				updated, err := client.UpdateInstance(ctx, instance.Metadata.Id, updateReq)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Metadata.Description).NotTo(BeNil())
+				Expect(*updated.Metadata.Description).To(Equal(updatedDescription))
+
+				retrieved, err := client.GetInstance(ctx, instance.Metadata.Id)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(retrieved.Metadata.Description).NotTo(BeNil())
+				Expect(*retrieved.Metadata.Description).To(Equal(updatedDescription),
+					"updated description should persist in subsequent GET")
+
+				GinkgoWriter.Printf("Instance %s description updated and verified via GET\n", instance.Metadata.Id)
+			})
+		})
+	})
+
 	Context("When creating an instance", func() {
 		Context("from a custom image", func() {
 			var (


### PR DESCRIPTION
Adds `UpdateInstance` to the typed API client and an integration test that updates an instance's description via PUT and asserts the change persists in a subsequent GET.

Closes INST-861.