### PR TITLE
Version v1.16.2

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: 1.16.1
-appVersion: 1.16.1
+version: 1.16.2
+appVersion: 1.16.2
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/spjmurray/go-util v0.1.3
 	github.com/stretchr/testify v1.11.1
 	github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e
-	github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed
-	github.com/unikorn-cloud/region v1.16.2
+	github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519
+	github.com/unikorn-cloud/region v1.16.3
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.49.0
 	k8s.io/api v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -251,10 +251,10 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e h1:BJBiASTtWfEJ1/yn26K18JxnMeLB4ucpuJcU0bVbpBo=
 github.com/unikorn-cloud/core v1.14.0-rc1.0.20260422145135-733e5169a07e/go.mod h1:t91+Hw7YbNt5nOtp93Ij826iQfYDcz6Og0KAi2xq+B8=
-github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed h1:2DBYOqaL2jMLhMFHLvS29a6jjTra8+Mdlos4FMpQBMc=
-github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260421095602-a005bcea5bed/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
-github.com/unikorn-cloud/region v1.16.2 h1:egnNcbDtWxxDctsoD8X+yrsaE0zhEjsEPik6BvKKSjY=
-github.com/unikorn-cloud/region v1.16.2/go.mod h1:vF80yPieVOiWEHJnViQbk0XkOYaSYr7I0kAgK0lwwPA=
+github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519 h1:ZNMADkrIRzM8BhEdRx1JEg4UnYcqcVmE+qWgh13jbyI=
+github.com/unikorn-cloud/identity v1.14.0-rc1.0.20260430090955-4839bc57a519/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
+github.com/unikorn-cloud/region v1.16.3 h1:OS5+DpRRAbQGlex63yDlAmTShsU68W1VO6ErzfAjuOc=
+github.com/unikorn-cloud/region v1.16.3/go.mod h1:uuiD+jLJsWjjTHxSb9fduHiRlgtQWrWvDMbyDRiA+9k=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=


### PR DESCRIPTION
Update the identity library and region dependency for impersonated principal account-type handling.

The shared identity middleware now populates the propagated principal type globally at the public API boundary from the authenticated request context, and the shared identity client injector forwards that principal automatically on downstream impersonated service-to-service calls.

This compute release picks up the region change that only patches request-scoped tenancy fields such as organization and project IDs when those values are known from the current route or resource context but are not already present on the propagated principal.