### PR TITLE
[codex] Reuse read-only API fixture instance

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -57,6 +57,7 @@ jobs:
       TEST_FLAVOR_ID: ${{ inputs.flavor_id_override || vars.DEV_TEST_FLAVOR_ID }}
       TEST_IMAGE_ID: ${{ inputs.image_id_override || vars.DEV_TEST_IMAGE_ID }}
       TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.DEV_TEST_NETWORK_ID }}
+      TEST_READONLY_INSTANCE_ID: ${{ vars.DEV_TEST_READONLY_INSTANCE_ID }}
 
     steps:
     - name: Validate region override inputs
@@ -158,6 +159,7 @@ jobs:
       TEST_FLAVOR_ID: ${{ inputs.flavor_id_override || vars.UAT_TEST_FLAVOR_ID }}
       TEST_IMAGE_ID: ${{ inputs.image_id_override || vars.UAT_TEST_IMAGE_ID }}
       TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.UAT_TEST_NETWORK_ID }}
+      TEST_READONLY_INSTANCE_ID: ${{ vars.UAT_TEST_READONLY_INSTANCE_ID }}
 
     steps:
     - name: Validate region override inputs

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ Tests are configured via environment variables using a `.env` file in the `test/
    - `TEST_REGION_ID` - Test region ID
    - `TEST_NETWORK_ID` - Test network ID
    - `TEST_FLAVOR_ID`, `TEST_IMAGE_ID` - Test flavor and image IDs
+   - `TEST_READONLY_INSTANCE_ID` - Optional pre-provisioned instance ID used by read-only
+     list, get, and console-output tests. Leave unset to create disposable instances.
 
 **Note:** All `test/.env` and `test/.env.*` files are gitignored and contain sensitive credentials. They should never be committed to the repository. You can use either `test/.env` directly or create environment-specific files like `test/.env.dev`, `test/.env.uat`, etc.
 
@@ -234,6 +236,11 @@ The API tests can be triggered manually via GitHub Actions using `workflow_dispa
 | `flavor_id_override` | string | Override flavor ID when overriding region | unset |
 | `image_id_override` | string | Override image ID when overriding region | unset |
 | `network_id_override` | string | Override network ID when overriding region | unset |
+
+The workflow also accepts optional repository or environment variables named
+`DEV_TEST_READONLY_INSTANCE_ID` and `UAT_TEST_READONLY_INSTANCE_ID`. When set,
+the read-only instance list, get, and console-output tests reuse that existing
+instance instead of creating one instance per spec.
 
 **Available Test Suite Options:**
 - `All` - Run all test suites

--- a/test/.env.example
+++ b/test/.env.example
@@ -32,6 +32,10 @@ TEST_NETWORK_ID=test-network-jkl012
 TEST_FLAVOR_ID=test-flavor-def456
 TEST_IMAGE_ID=test-image-ghi789
 
+# Optional read-only fixture instance used by list/get/console-output tests.
+# Leave empty to create disposable instances during local/default runs.
+TEST_READONLY_INSTANCE_ID=
+
 # Test timeout settings
 REQUEST_TIMEOUT=30s
 TEST_TIMEOUT=20m

--- a/test/api/config.go
+++ b/test/api/config.go
@@ -33,6 +33,7 @@ type TestConfig struct {
 	FlavorID             string
 	ImageID              string
 	NetworkID            string
+	ReadOnlyInstanceID   string
 	EnableSSHIntegration bool
 }
 
@@ -81,6 +82,7 @@ func LoadTestConfig() (*TestConfig, error) {
 		FlavorID:             v.GetString("TEST_FLAVOR_ID"),
 		ImageID:              v.GetString("TEST_IMAGE_ID"),
 		NetworkID:            v.GetString("TEST_NETWORK_ID"),
+		ReadOnlyInstanceID:   v.GetString("TEST_READONLY_INSTANCE_ID"),
 		EnableSSHIntegration: v.GetBool("ENABLE_SSH_INTEGRATION"),
 	}
 

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -176,6 +176,23 @@ func CreateInstanceWithCleanup(client *APIClient, ctx context.Context, config *T
 	return instance, instanceID
 }
 
+// UseReadOnlyInstanceOrCreateWithCleanup returns the configured read-only fixture when present,
+// otherwise it creates a disposable instance and schedules cleanup for local/default runs.
+func UseReadOnlyInstanceOrCreateWithCleanup(client *APIClient, ctx context.Context, config *TestConfig, payload openapi.InstanceCreate) (openapi.InstanceRead, string) {
+	if config.ReadOnlyInstanceID == "" {
+		return CreateInstanceWithCleanup(client, ctx, config, payload)
+	}
+
+	instance, err := client.GetInstance(ctx, config.ReadOnlyInstanceID)
+	Expect(err).NotTo(HaveOccurred(), "Failed to get configured read-only instance %s", config.ReadOnlyInstanceID)
+	Expect(instance.Metadata.Id).To(Equal(config.ReadOnlyInstanceID))
+	Expect(instance.Metadata.ProvisioningStatus).To(Equal(coreapi.ResourceProvisioningStatusProvisioned))
+
+	GinkgoWriter.Printf("Using configured read-only instance: %s\n", config.ReadOnlyInstanceID)
+
+	return instance, config.ReadOnlyInstanceID
+}
+
 // WaitForInstanceActive waits for an instance to reach active/running power state.
 func WaitForInstanceActive(client *APIClient, ctx context.Context, config *TestConfig, instanceID string) {
 	Eventually(func() string {

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Instance Operations", func() {
 			var instanceID string
 
 			BeforeEach(func() {
-				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
+				_, iID := api.UseReadOnlyInstanceOrCreateWithCleanup(client, ctx, config,
 					api.NewInstancePayload().Build())
 				instanceID = iID
 				GinkgoWriter.Printf("Using instance %s for list test\n", instanceID)
@@ -241,13 +241,11 @@ var _ = Describe("Instance Operations", func() {
 			var instanceID string
 
 			BeforeEach(func() {
-				// Create an instance for console output tests
-				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
+				_, iID := api.UseReadOnlyInstanceOrCreateWithCleanup(client, ctx, config,
 					api.NewInstancePayload().Build())
 
 				instanceID = iID
 
-				// Wait for network identity and running state so console output is available
 				api.WaitForInstanceNetworkIdentity(client, ctx, config, instanceID)
 				api.WaitForInstanceActive(client, ctx, config, instanceID)
 
@@ -550,8 +548,7 @@ var _ = Describe("Instance Operations", func() {
 			var instanceID string
 
 			BeforeEach(func() {
-				// Create an instance for retrieval tests
-				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
+				_, iID := api.UseReadOnlyInstanceOrCreateWithCleanup(client, ctx, config,
 					api.NewInstancePayload().Build())
 
 				instanceID = iID


### PR DESCRIPTION
## Summary

This change lets the read-only compute API tests reuse a pre-provisioned instance when `TEST_READONLY_INSTANCE_ID` is configured.

The converted tests are intentionally limited to read-only behavior:

- list instances includes the known instance
- get instance metadata
- console output positive cases

Stateful tests still create disposable instances for update, delete, power operations, create-from-image, and snapshot behavior.

## Why

The API suite currently creates an instance for every positive instance spec. Recent API test runs show the suite is dominated by provisioning waits and resource cleanup, and long-running setup can cause the suite to abort before later specs run. Reusing a known read-only instance reduces resource pressure without weakening lifecycle coverage.

For the staged instance that was created for this work, set the UAT repository/environment variable:

```text
UAT_TEST_READONLY_INSTANCE_ID=deba807f-b278-4825-ace9-fce18f5dd56c
```

Dev can opt in independently with:

```text
DEV_TEST_READONLY_INSTANCE_ID=<dev fixture instance id>
```

If either variable is unset, tests fall back to the existing behavior and create disposable instances.

## Validation

- `go test ./test/api/...`
- `go test -tags=integration ./test/api/suites -run '^$'`
- `git diff --check`