### PR TITLE
test(api): identify and clean stale E2E compute instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ Tests are configured via environment variables using a `.env` file in the `test/
    - `TEST_REGION_ID` - Test region ID
    - `TEST_NETWORK_ID` - Test network ID
    - `TEST_FLAVOR_ID`, `TEST_IMAGE_ID` - Test flavor and image IDs
-
 **Note:** All `test/.env` and `test/.env.*` files are gitignored and contain sensitive credentials. They should never be committed to the repository. You can use either `test/.env` directly or create environment-specific files like `test/.env.dev`, `test/.env.uat`, etc.
 
 #### Running Tests Locally (run from project root)
@@ -203,6 +202,13 @@ make test-api-focus FOCUS="Instance Operations"
 # Example: run only a specific test spec by name
 make test-api-focus FOCUS="should successfully stop a running instance"
 ```
+
+The instance operations suite checks for leftover API test instances in the
+configured project before running its specs. CI-created instances use the
+`e2e-uni-compute-ci-` prefix, local instances use `e2e-uni-compute-local-`, and
+cleanup only requests deletion for instances older than one hour whose names
+match the current environment prefix. It prints GitHub Actions `::error::`
+annotations and continues without deleting instances from other active builds.
 
 **Advanced Ginkgo options:**
 ```bash

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,6 +37,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const TestResourceNamePrefix = "e2e-uni-compute"
+
+func TestResourceEnvironmentPrefix() string {
+	if strings.EqualFold(os.Getenv("GITHUB_ACTIONS"), "true") || strings.EqualFold(os.Getenv("CI"), "true") {
+		return TestResourceNamePrefix + "-ci"
+	}
+
+	return TestResourceNamePrefix + "-local"
+}
+
 // InstancePayloadBuilder builds instance payloads for testing using type-safe OpenAPI structs.
 type InstancePayloadBuilder struct {
 	instance openapi.InstanceCreate
@@ -46,7 +58,7 @@ func NewInstancePayload() *InstancePayloadBuilder {
 	config, err := LoadTestConfig()
 	Expect(err).NotTo(HaveOccurred(), "Failed to load test configuration")
 
-	uniqueName := fmt.Sprintf("testinstance-%s", uuid.NewString()[:8])
+	uniqueName := fmt.Sprintf("%s-%s", TestResourceEnvironmentPrefix(), uuid.NewString()[:8])
 
 	return &InstancePayloadBuilder{
 		config: config,
@@ -137,7 +149,7 @@ func CreateInstanceWithCleanup(client *APIClient, ctx context.Context, config *T
 			return
 		}
 
-		GinkgoWriter.Printf("Cleaning up instance: %s\n", instanceID)
+		GinkgoWriter.Printf("Cleaning up instance %q (%s)\n", instanceName, instanceID)
 		Expect(client.DeleteInstance(ctx, instanceID)).To(Succeed())
 
 		GinkgoWriter.Printf("Waiting for instance %s to be fully deleted\n", instanceID)
@@ -154,7 +166,7 @@ func CreateInstanceWithCleanup(client *APIClient, ctx context.Context, config *T
 
 	instanceID = instance.Metadata.Id
 
-	GinkgoWriter.Printf("Created instance with ID: %s\n", instanceID)
+	GinkgoWriter.Printf("Created instance %q with ID: %s\n", instanceName, instanceID)
 
 	// Wait for instance to be provisioned
 	Eventually(func() string {

--- a/test/api/stale_instances.go
+++ b/test/api/stale_instances.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const staleInstanceMinimumAge = time.Hour
+
+// CleanupStaleTestInstances requests deletion for leaked API test instances and
+// logs stale findings as GitHub Actions annotations.
+func CleanupStaleTestInstances(ctx context.Context, client *APIClient, organizationID, projectID, prefix string) error {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		fmt.Println("::error::Skipping stale compute instance cleanup: prefix is empty")
+
+		return nil
+	}
+
+	instances, err := client.ListInstances(ctx, organizationID, projectID)
+	if err != nil {
+		return fmt.Errorf("listing instances: %w", err)
+	}
+
+	var (
+		found int
+		now   = time.Now()
+	)
+
+	for _, instance := range instances {
+		if !strings.HasPrefix(instance.Metadata.Name, prefix) {
+			continue
+		}
+
+		if now.Sub(instance.Metadata.CreationTime) <= staleInstanceMinimumAge {
+			continue
+		}
+
+		found++
+
+		fmt.Printf("::error::Found stale compute instance %q (%s), status=%s, created=%s\n",
+			instance.Metadata.Name,
+			instance.Metadata.Id,
+			instance.Metadata.ProvisioningStatus,
+			instance.Metadata.CreationTime.Format(time.RFC3339),
+		)
+
+		if err := client.DeleteInstance(ctx, instance.Metadata.Id); err != nil {
+			fmt.Printf("::error::Failed to delete stale compute instance %q (%s): %v\n",
+				instance.Metadata.Name,
+				instance.Metadata.Id,
+				err,
+			)
+
+			continue
+		}
+
+		fmt.Printf("Requested cleanup for stale compute instance %q (%s)\n", instance.Metadata.Name, instance.Metadata.Id)
+	}
+
+	if found == 0 {
+		fmt.Printf("No stale compute API test instances found with prefix %q\n", prefix)
+	}
+
+	return nil
+}

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package suites
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -36,7 +37,18 @@ import (
 
 const nonExistentInstanceID = "non-existent-instance-12345"
 
-var _ = Describe("Instance Operations", func() {
+// Ginkgo supports BeforeAll only inside ordered containers. ContinueOnFailure
+// keeps later instance specs eligible to run after a spec failure.
+var _ = Describe("Instance Operations", Ordered, ContinueOnFailure, func() {
+	BeforeAll(func() {
+		cleanupConfig, err := api.LoadTestConfig()
+		Expect(err).NotTo(HaveOccurred(), "Failed to load test configuration for stale instance cleanup")
+
+		cleanupClient := api.NewAPIClientWithConfig(cleanupConfig)
+		Expect(api.CleanupStaleTestInstances(context.Background(), cleanupClient, cleanupConfig.OrgID, cleanupConfig.ProjectID, api.TestResourceEnvironmentPrefix()+"-")).
+			To(Succeed(), "stale instance cleanup failed")
+	})
+
 	Context("When listing instances", func() {
 		Describe("Given a provisioned instance", func() {
 			var instanceID string


### PR DESCRIPTION
## Summary

- Introduces a shared `e2e-uni-compute` prefix for instances created by the API integration test fixtures.
- Adds pre-suite cleanup for leaked compute API test instances older than one hour whose names use that prefix.
- Keeps cleanup scoped to known test-created resources, leaves active builds/unrelated resources alone, and emits GitHub Actions annotations for stale findings.
- Improves instance fixture logging and documents the stale cleanup behavior in the README.

## Why

The previous `testinstance-*` names were too generic in shared cloud environments. The explicit `e2e-uni-compute-*` prefix makes test-created instances easier to audit and lets the suite safely clean up stale leftovers without touching unrelated resources.

## Validation

- `go test ./test/api/...`
- `go test -tags=integration ./test/api/suites -run '^$'`\n- `git diff --check`