### PR TITLE
test(api): speed up integration test suite

### DIFF
--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -46,8 +46,7 @@ func NewInstancePayload() *InstancePayloadBuilder {
 	config, err := LoadTestConfig()
 	Expect(err).NotTo(HaveOccurred(), "Failed to load test configuration")
 
-	timestamp := time.Now().Format("20060102-150405")
-	uniqueName := fmt.Sprintf("testinstance-%s", timestamp)
+	uniqueName := fmt.Sprintf("testinstance-%s", uuid.NewString()[:8])
 
 	return &InstancePayloadBuilder{
 		config: config,
@@ -183,6 +182,10 @@ func WaitForInstanceActive(client *APIClient, ctx context.Context, config *TestC
 		if err != nil {
 			GinkgoWriter.Printf("Error getting instance: %v\n", err)
 			return "error"
+		}
+
+		if instance.Metadata.HealthStatus == coreapi.ResourceHealthStatusError {
+			Fail(fmt.Sprintf("Instance %s entered error health status", instanceID))
 		}
 
 		if instance.Status.PowerState == nil {
@@ -346,12 +349,10 @@ type ImagePayloadBuilder struct {
 
 // NewImagePayload creates a builder with sensible defaults.
 func NewImagePayload() *ImagePayloadBuilder {
-	timestamp := time.Now().Format("20060102-150405")
-
 	return &ImagePayloadBuilder{
 		image: regionopenapi.ImageCreate{
 			Metadata: coreapi.ResourceWriteMetadata{
-				Name: fmt.Sprintf("ginkgo-test-image-%s", timestamp),
+				Name: fmt.Sprintf("ginkgo-test-image-%s", uuid.NewString()[:8]),
 			},
 			Spec: regionopenapi.ImageCreateSpec{
 				Architecture:   regionopenapi.ArchitectureX8664,

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -237,17 +237,16 @@ var _ = Describe("Instance Operations", func() {
 	})
 
 	Context("When retrieving console output for an instance", func() {
-		Describe("Given a valid instance exists", func() {
+		Describe("Given a valid instance exists", Ordered, func() {
 			var instanceID string
 
-			BeforeEach(func() {
-				// Create an instance for console output tests
+			BeforeAll(func() {
+				// Create a single instance shared across all console output specs.
 				_, iID := api.CreateInstanceWithCleanup(client, ctx, config,
 					api.NewInstancePayload().Build())
 
 				instanceID = iID
 
-				// Wait for network identity and running state so console output is available
 				api.WaitForInstanceNetworkIdentity(client, ctx, config, instanceID)
 				api.WaitForInstanceActive(client, ctx, config, instanceID)
 


### PR DESCRIPTION
Some changes to reduce run time:

- Use UUID suffixes for instance/image names instead of timestamps, making names collision-safe when running with --procs=N in parallel.
- Add fail-fast on healthStatus=error in WaitForInstanceActive so broken instances abort immediately rather than burning the full TestTimeout.
- Convert the console output Describe block to Ordered+BeforeAll so all three specs share one provisioned instance instead of each creating their own, saving ~2 minutes in serial runs.