### PR TITLE
ci: support selected-ref UAT runs

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -12,6 +12,14 @@ on:
         description: 'Run UAT tests'
         type: boolean
         default: false
+      use_staging_constellation:
+        description: 'Use the staged constellation tag for UAT checkout'
+        type: boolean
+        default: true
+      skip_slack_notifications:
+        description: 'Skip Slack notifications'
+        type: boolean
+        default: false
       focus:
         description: 'Test suite to run'
         required: false
@@ -120,7 +128,7 @@ jobs:
 
     - name: Send Slack Notification
       uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
       with:
         test-results-path: test/api/suites/test-results.json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -129,24 +137,26 @@ jobs:
         title: 'Compute API Test Results'
 
   find-staging-constellation:
-    name: Find staging constellation
+    name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
     outputs:
-      tag: ${{ steps.find.outputs.tag }}
+      ref: ${{ steps.find.outputs.ref }}
     steps:
-    - uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
+    - name: Resolve UAT checkout ref
+      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
       id: find
       with:
         service: uni-compute
         releases-read-token: ${{ secrets.RELEASES_READ_TOKEN }}
+        use-staging-constellation: ${{ github.event_name == 'schedule' || github.event.inputs.use_staging_constellation != 'false' }}
 
   API-Tests-UAT:
     name: API Tests (uat)
     needs: find-staging-constellation
     runs-on: ubuntu-latest
-    # Runs only when find-staging-constellation resolved a tag.
-    if: needs.find-staging-constellation.outputs.tag != ''
+    # Runs only when the resolver produced a UAT checkout ref.
+    if: needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -175,7 +185,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ needs.find-staging-constellation.outputs.tag }}
+        ref: ${{ needs.find-staging-constellation.outputs.ref }}
 
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -223,10 +233,10 @@ jobs:
 
     - name: Send Slack Notification
       uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() }}
+      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
       with:
         test-results-path: test/api/suites/test-results.json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         environment: uat
-        title: 'Compute API Test Results'
+        title: 'Compute API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ The API tests can be triggered manually via GitHub Actions using `workflow_dispa
 |-------|------|-------------|---------|
 | `run_dev` | boolean | Run Dev environment tests | `true` |
 | `run_uat` | boolean | Run UAT environment tests | `false` |
+| `use_staging_constellation` | boolean | Use the staged constellation tag for UAT checkout | `true` |
+| `skip_slack_notifications` | boolean | Skip Slack notifications for this run | `false` |
 | `focus` | choice | Test suite to run | `All` |
 | `region_id_override` | string | Override region ID for manual runs | unset |
 | `flavor_id_override` | string | Override flavor ID when overriding region | unset |
@@ -243,6 +245,13 @@ The API tests can be triggered manually via GitHub Actions using `workflow_dispa
 If `region_id_override` is set, `flavor_id_override`, `image_id_override`, and
 `network_id_override` must also be provided.
 
+Scheduled UAT runs check out the staged constellation tag resolved by the
+workflow. Manual UAT runs use the same staged constellation lookup by default.
+To run UAT against the branch or tag selected in GitHub's manual workflow
+picker instead, set `use_staging_constellation` to `false`. Disabling
+`use_staging_constellation` is enough to trigger the UAT job for that selected
+ref.
+
 **Triggering Manually:**
 
 1. Navigate to **Actions** tab in GitHub
@@ -252,7 +261,11 @@ If `region_id_override` is set, `flavor_id_override`, `image_id_override`, and
    - **Run Dev tests** (checked by default)
    - **Run UAT tests** (unchecked by default)
 5. Choose test suite from the **focus** dropdown
-6. Click **Run workflow**
+6. To test UAT from the selected workflow branch or tag, set
+   **use_staging_constellation** to `false`
+7. To suppress Slack messages for the run, set
+   **skip_slack_notifications** to `true`
+8. Click **Run workflow**
 
 **Test Artifacts:**
 


### PR DESCRIPTION
## Summary
- Add a `use_staging_constellation` workflow input, defaulting to the existing staging constellation lookup.
- Use the shared resolver `ref` output for UAT checkout so both staged tags and manually selected workflow refs work.
- Allow manual UAT runs from the branch/tag selected in the GitHub run picker when staging lookup is disabled.
- Include the resolved UAT checkout ref in the UAT Slack notification title.
- Add `skip_slack_notifications` to suppress Slack messages for a manual run.

## Dependency
- Requires nscaledev/quality-tooling#6 to be merged so `uni-find-staging-constellation@main` exposes the new `use-staging-constellation` input and `ref` output.

## Backward Compatibility
- Scheduled runs and existing manual runs keep using the staged constellation by default.
- Slack notifications continue by default unless `skip_slack_notifications` is set to `true`.
- UAT still skips when the resolver does not produce a checkout ref.

## Validation
- Parsed `.github/workflows/test-api.yaml` as YAML
- `git diff --check`