### PR TITLE
feat(test): Report Compute API test results with AI Slack analysis

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -158,13 +158,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Compute API Test Results'
@@ -267,13 +267,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Compute API Test Results'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -127,7 +127,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
@@ -236,7 +236,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -143,7 +143,7 @@ jobs:
   find-staging-constellation:
     name: Resolve UAT test ref
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true' || github.event.inputs.use_staging_constellation == 'false'
+    if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
     steps:
@@ -160,7 +160,7 @@ jobs:
     needs: find-staging-constellation
     runs-on: ubuntu-latest
     # Runs only when the resolver produced a UAT checkout ref.
-    if: needs.find-staging-constellation.outputs.ref != ''
+    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -245,6 +245,6 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
-        title: 'Compute API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'
+        title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -67,6 +67,33 @@ jobs:
       TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.DEV_TEST_NETWORK_ID }}
 
     steps:
+    - name: Log workflow inputs
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
+        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
+        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
+        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
+        FOCUS: ${{ github.event.inputs.focus || 'All' }}
+        REGION_ID_OVERRIDE: ${{ inputs.region_id_override || '<default>' }}
+        FLAVOR_ID_OVERRIDE: ${{ inputs.flavor_id_override || '<default>' }}
+        IMAGE_ID_OVERRIDE: ${{ inputs.image_id_override || '<default>' }}
+        NETWORK_ID_OVERRIDE: ${{ inputs.network_id_override || '<default>' }}
+      run: |
+        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+        ### Workflow Input Parameters
+        - **Event:** \`$EVENT_NAME\`
+        - **Run Dev:** \`$RUN_DEV\`
+        - **Run UAT:** \`$RUN_UAT\`
+        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
+        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
+        - **Focus:** \`$FOCUS\`
+        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
+        - **Flavor ID Override:** \`$FLAVOR_ID_OVERRIDE\`
+        - **Image ID Override:** \`$IMAGE_ID_OVERRIDE\`
+        - **Network ID Override:** \`$NETWORK_ID_OVERRIDE\`
+        EOF
+
     - name: Validate region override inputs
       if: github.event_name == 'workflow_dispatch' && inputs.region_id_override != ''
       run: |
@@ -174,6 +201,35 @@ jobs:
       TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.UAT_TEST_NETWORK_ID }}
 
     steps:
+    - name: Log workflow inputs
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
+        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
+        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
+        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
+        FOCUS: ${{ github.event.inputs.focus || 'All' }}
+        REGION_ID_OVERRIDE: ${{ inputs.region_id_override || '<default>' }}
+        FLAVOR_ID_OVERRIDE: ${{ inputs.flavor_id_override || '<default>' }}
+        IMAGE_ID_OVERRIDE: ${{ inputs.image_id_override || '<default>' }}
+        NETWORK_ID_OVERRIDE: ${{ inputs.network_id_override || '<default>' }}
+        UAT_CHECKOUT_REF: ${{ needs.find-staging-constellation.outputs.ref }}
+      run: |
+        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+        ### Workflow Input Parameters
+        - **Event:** \`$EVENT_NAME\`
+        - **Run Dev:** \`$RUN_DEV\`
+        - **Run UAT:** \`$RUN_UAT\`
+        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
+        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
+        - **Focus:** \`$FOCUS\`
+        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
+        - **Flavor ID Override:** \`$FLAVOR_ID_OVERRIDE\`
+        - **Image ID Override:** \`$IMAGE_ID_OVERRIDE\`
+        - **Network ID Override:** \`$NETWORK_ID_OVERRIDE\`
+        - **UAT Checkout Ref:** \`$UAT_CHECKOUT_REF\`
+        EOF
+
     - name: Validate region override inputs
       if: github.event_name == 'workflow_dispatch' && inputs.region_id_override != ''
       run: |

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -50,22 +50,9 @@ permissions:
   contents: read
 
 jobs:
-  API-Tests-Dev:
-    name: API Tests (dev)
+  workflow-inputs-summary:
+    name: Workflow input summary
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
-    env:
-      ENVIRONMENT: dev
-      API_BASE_URL: ${{ vars.DEV_API_BASE_URL }}
-      REGION_BASE_URL: ${{ vars.DEV_REGION_BASE_URL }}
-      API_AUTH_TOKEN: ${{ secrets.DEV_API_AUTH_TOKEN }}
-      TEST_ORG_ID: ${{ vars.DEV_TEST_ORG_ID }}
-      TEST_PROJECT_ID: ${{ vars.DEV_TEST_PROJECT_ID }}
-      TEST_REGION_ID: ${{ inputs.region_id_override || vars.DEV_TEST_REGION_ID }}
-      TEST_FLAVOR_ID: ${{ inputs.flavor_id_override || vars.DEV_TEST_FLAVOR_ID }}
-      TEST_IMAGE_ID: ${{ inputs.image_id_override || vars.DEV_TEST_IMAGE_ID }}
-      TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.DEV_TEST_NETWORK_ID }}
-
     steps:
     - name: Log workflow inputs
       env:
@@ -94,6 +81,23 @@ jobs:
         - **Network ID Override:** \`$NETWORK_ID_OVERRIDE\`
         EOF
 
+  API-Tests-Dev:
+    name: API Tests (dev)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
+    env:
+      ENVIRONMENT: dev
+      API_BASE_URL: ${{ vars.DEV_API_BASE_URL }}
+      REGION_BASE_URL: ${{ vars.DEV_REGION_BASE_URL }}
+      API_AUTH_TOKEN: ${{ secrets.DEV_API_AUTH_TOKEN }}
+      TEST_ORG_ID: ${{ vars.DEV_TEST_ORG_ID }}
+      TEST_PROJECT_ID: ${{ vars.DEV_TEST_PROJECT_ID }}
+      TEST_REGION_ID: ${{ inputs.region_id_override || vars.DEV_TEST_REGION_ID }}
+      TEST_FLAVOR_ID: ${{ inputs.flavor_id_override || vars.DEV_TEST_FLAVOR_ID }}
+      TEST_IMAGE_ID: ${{ inputs.image_id_override || vars.DEV_TEST_IMAGE_ID }}
+      TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.DEV_TEST_NETWORK_ID }}
+
+    steps:
     - name: Validate region override inputs
       if: github.event_name == 'workflow_dispatch' && inputs.region_id_override != ''
       run: |
@@ -201,35 +205,6 @@ jobs:
       TEST_NETWORK_ID: ${{ inputs.network_id_override || vars.UAT_TEST_NETWORK_ID }}
 
     steps:
-    - name: Log workflow inputs
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        RUN_DEV: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_dev || 'true' }}
-        RUN_UAT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.run_uat || 'false' }}
-        USE_STAGING_CONSTELLATION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_staging_constellation || 'true' }}
-        SKIP_SLACK_NOTIFICATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.skip_slack_notifications || 'false' }}
-        FOCUS: ${{ github.event.inputs.focus || 'All' }}
-        REGION_ID_OVERRIDE: ${{ inputs.region_id_override || '<default>' }}
-        FLAVOR_ID_OVERRIDE: ${{ inputs.flavor_id_override || '<default>' }}
-        IMAGE_ID_OVERRIDE: ${{ inputs.image_id_override || '<default>' }}
-        NETWORK_ID_OVERRIDE: ${{ inputs.network_id_override || '<default>' }}
-        UAT_CHECKOUT_REF: ${{ needs.find-staging-constellation.outputs.ref }}
-      run: |
-        cat <<EOF >> "$GITHUB_STEP_SUMMARY"
-        ### Workflow Input Parameters
-        - **Event:** \`$EVENT_NAME\`
-        - **Run Dev:** \`$RUN_DEV\`
-        - **Run UAT:** \`$RUN_UAT\`
-        - **Use Staging Constellation:** \`$USE_STAGING_CONSTELLATION\`
-        - **Skip Slack Notifications:** \`$SKIP_SLACK_NOTIFICATIONS\`
-        - **Focus:** \`$FOCUS\`
-        - **Region ID Override:** \`$REGION_ID_OVERRIDE\`
-        - **Flavor ID Override:** \`$FLAVOR_ID_OVERRIDE\`
-        - **Image ID Override:** \`$IMAGE_ID_OVERRIDE\`
-        - **Network ID Override:** \`$NETWORK_ID_OVERRIDE\`
-        - **UAT Checkout Ref:** \`$UAT_CHECKOUT_REF\`
-        EOF
-
     - name: Validate region override inputs
       if: github.event_name == 'workflow_dispatch' && inputs.region_id_override != ''
       run: |

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -158,13 +158,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Compute API Test Results'
@@ -267,13 +267,13 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
         format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        slack-webhook-url: ${{ secrets.SLACK_API_TESTING_TMP_WEBHOOK_URL }}
+        slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Compute API Test Results'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -126,15 +126,19 @@ jobs:
         linear-priority: '3'
         max-failures: '5'
 
-    - name: Send Slack Notification
-      uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
+    - name: Report API Test Results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
+        format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Compute API Test Results'
+        enable-ai-analysis: 'true'
+        claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   find-staging-constellation:
     name: Resolve UAT test ref
@@ -231,12 +235,16 @@ jobs:
         linear-priority: '3'
         max-failures: '5'
 
-    - name: Send Slack Notification
-      uses: nscaledev/quality-tooling/.github/actions/slack-test-notifications@main
-      if: ${{ !cancelled() && github.event.inputs.skip_slack_notifications != 'true' }}
+    - name: Report API Test Results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-results-report-action
+      if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
+        format: ginkgo-json
         workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+        send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Compute API Test Results - ${{ needs.find-staging-constellation.outputs.ref }}'
+        enable-ai-analysis: 'true'
+        claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace the legacy Slack test notification step with the shared `test-results-report` action for dev and UAT API test jobs.
- Send Ginkgo JSON results through the report action, keeping Slack delivery configurable via `skip_slack_notifications`.
- Enable Claude analysis for Compute API test reports while preserving the latest selected-ref UAT workflow from `main`.
- - Sample [build](https://github.com/nscaledev/uni-region/actions/runs/26182133497), slack msg
<img width="1238" height="605" alt="Screenshot 2026-05-20 at 19 50 02" src="https://github.com/user-attachments/assets/5bfc79c7-819c-4297-a1e2-513d83ce6eb2" />

## Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-api.yaml"); puts "ok"'`
- `git diff --check`
- `actionlint` not run locally; command is not installed.