### PR TITLE
Hide pinned-only flavors from compute

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/unikorn-cloud/core v1.16.2-0.20260521095345-d5bfecbc9403
 	github.com/unikorn-cloud/identity v1.17.1
-	github.com/unikorn-cloud/region v1.16.3
+	github.com/unikorn-cloud/region v1.17.1-0.20260611120610-26139f65191a
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.49.0
 	k8s.io/api v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/unikorn-cloud/identity v1.17.1 h1:bFYfe7IGBJb1EdaiDTZPmv+E3B814PUNkiP
 github.com/unikorn-cloud/identity v1.17.1/go.mod h1:N5F9BXYWcv5VKNgKo/NRWII+A4x+KGiDlU7o1c/rU54=
 github.com/unikorn-cloud/region v1.16.3 h1:OS5+DpRRAbQGlex63yDlAmTShsU68W1VO6ErzfAjuOc=
 github.com/unikorn-cloud/region v1.16.3/go.mod h1:uuiD+jLJsWjjTHxSb9fduHiRlgtQWrWvDMbyDRiA+9k=
+github.com/unikorn-cloud/region v1.17.1-0.20260611120610-26139f65191a h1:4xa9O1FrCD90KL2/z8ptItVn271qUB05drynyrOMFMs=
+github.com/unikorn-cloud/region v1.17.1-0.20260611120610-26139f65191a/go.mod h1:nBHfQBbpbdh+Vv1VR69Oy3n9Q3tKx+WeHDze8NTZNaU=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/pkg/server/handler/README.md
+++ b/pkg/server/handler/README.md
@@ -24,6 +24,9 @@ that ties those two pieces together under one HTTP API.
   normalization, then delegate actual policy and mutation logic downward.
 - Read-side region/flavor/image endpoints impersonate the caller into region so
   region remains the authority on visibility.
+- Flavor discovery excludes region flavors marked `pinnedOnly`, because compute
+  instances do not expose `infrastructureRef` host pinning and those flavors
+  would be rejected by region during backing server creation.
 - The `.well-known/openid-protected-resource` endpoint is cacheable and is part
   of the service trust contract, not just a convenience route.
 

--- a/pkg/server/handler/region/region.go
+++ b/pkg/server/handler/region/region.go
@@ -72,7 +72,13 @@ func (c *Client) Flavors(ctx context.Context, organizationID, regionID string) (
 		return nil, errors.PropagateError(resp.HTTPResponse, resp)
 	}
 
-	return *resp.JSON200, nil
+	flavors := *resp.JSON200
+
+	filtered := slices.DeleteFunc(flavors, func(flavor regionapi.Flavor) bool {
+		return flavor.Spec.PinnedOnly != nil && *flavor.Spec.PinnedOnly
+	})
+
+	return filtered, nil
 }
 
 // Images returns all compute compatible images.

--- a/pkg/server/handler/region/region_test.go
+++ b/pkg/server/handler/region/region_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Nscale.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package region_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	computeregion "github.com/unikorn-cloud/compute/pkg/server/handler/region"
+	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
+
+	"k8s.io/utils/ptr"
+)
+
+func TestFlavorsFiltersPinnedOnly(t *testing.T) {
+	t.Parallel()
+
+	const (
+		organizationID = "org1"
+		regionID       = "region1"
+	)
+
+	flavors := []regionapi.Flavor{
+		flavor("general", nil),
+		flavor("pinned", ptr.To(true)),
+		flavor("explicitly-unpinned", ptr.To(false)),
+	}
+
+	body, err := json.Marshal(flavors)
+	require.NoError(t, err)
+
+	client, err := regionapi.NewClientWithResponses("http://region.example", regionapi.WithHTTPClient(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/api/v1/organizations/org1/regions/region1/flavors", r.URL.Path)
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(body)),
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Request:    r,
+		}, nil
+	})))
+	require.NoError(t, err)
+
+	filtered, err := computeregion.New(client).Flavors(t.Context(), organizationID, regionID)
+	require.NoError(t, err)
+
+	require.Len(t, filtered, 2)
+	assert.Equal(t, "general", filtered[0].Metadata.Id)
+	assert.Equal(t, "explicitly-unpinned", filtered[1].Metadata.Id)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func flavor(id string, pinnedOnly *bool) regionapi.Flavor {
+	return regionapi.Flavor{
+		Metadata: coreapi.StaticResourceMetadata{
+			Id: id,
+		},
+		Spec: regionapi.FlavorSpec{
+			Architecture: regionapi.ArchitectureX8664,
+			Cpus:         1,
+			Disk:         20,
+			Memory:       1,
+			PinnedOnly:   pinnedOnly,
+		},
+	}
+}

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -371,8 +371,8 @@ func NewImagePayload() *ImagePayloadBuilder {
 				Virtualization: regionopenapi.ImageVirtualizationVirtualized,
 				Os: regionopenapi.ImageOS{
 					Codename: ptr.To("cirros"),
-					Distro:   regionopenapi.OsDistroUbuntu,
-					Family:   regionopenapi.OsFamilyDebian,
+					Distro:   "ubuntu",
+					Family:   "debian",
 					Kernel:   regionopenapi.OsKernelLinux,
 					Version:  "0.6.3",
 				},


### PR DESCRIPTION
The region service will accept server spec that pin to a specific host (https://github.com/nscaledev/uni-region/pull/488), but this is guarded per flavour with a property `pinnedOnly` (https://github.com/nscaledev/uni-region/pull/491).

Compute instances do not accept `infrastructureRef`, so region would reject pinnedOnly flavors when creating the backing server. Filter them from discovery so compute only advertises flavors it can provision.
