### PR TITLE
feat(observability): Add diagnostics for instance health failures

### DIFF
--- a/pkg/provisioners/managers/instance/provisioner.go
+++ b/pkg/provisioners/managers/instance/provisioner.go
@@ -40,6 +40,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Options allows access to CLI options in the provisioner.
@@ -277,6 +279,55 @@ func (p *Provisioner) updateInstanceStatus(server *regionapi.ServerV2Response) {
 	p.instance.Status.PowerState = convertPowerState(server.Status.PowerState)
 }
 
+func shouldLogUnhealthyServerTransition(serverHealth coreapi.ResourceHealthStatus, previousHealthReason unikornv1core.ConditionReason) bool {
+	var reason unikornv1core.ConditionReason
+
+	switch serverHealth {
+	case coreapi.ResourceHealthStatusDegraded:
+		reason = unikornv1core.ConditionReasonDegraded
+	case coreapi.ResourceHealthStatusError:
+		reason = unikornv1core.ConditionReasonErrored
+	case coreapi.ResourceHealthStatusHealthy, coreapi.ResourceHealthStatusUnknown:
+		return false
+	}
+
+	return previousHealthReason != reason
+}
+
+func healthConditionReason(conditions []unikornv1core.Condition) unikornv1core.ConditionReason {
+	condition, err := unikornv1core.GetCondition(conditions, unikornv1core.ConditionHealthy)
+	if err != nil {
+		return ""
+	}
+
+	return condition.Reason
+}
+
+func (p *Provisioner) logUnhealthyServer(ctx context.Context, server *regionapi.ServerV2Response, previousHealthReason unikornv1core.ConditionReason) {
+	if !shouldLogUnhealthyServerTransition(server.Metadata.HealthStatus, previousHealthReason) {
+		return
+	}
+
+	powerState := "<nil>"
+	if server.Status.PowerState != nil {
+		powerState = string(*server.Status.PowerState)
+	}
+
+	log.FromContext(ctx).Info("backing server reported unhealthy status",
+		"name", p.instance.Name,
+		"namespace", p.instance.Namespace,
+		"serverID", server.Metadata.Id,
+		"serverName", server.Metadata.Name,
+		"serverHealthStatus", server.Metadata.HealthStatus,
+		"serverProvisioningStatus", server.Metadata.ProvisioningStatus,
+		"serverPowerState", powerState,
+		"regionID", server.Status.RegionId,
+		"networkID", server.Status.NetworkId,
+		"imageID", server.Spec.ImageId,
+		"flavorID", server.Spec.FlavorId,
+	)
+}
+
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	region, err := p.getRegionClient(ctx)
@@ -294,9 +345,11 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return err
 	}
 
+	previousHealthReason := healthConditionReason(p.instance.Status.Conditions)
 	healthStatus, healthReason, healthMessage := convertHealthStatusCondition(server.Metadata.HealthStatus)
 	unikornv1core.UpdateCondition(&p.instance.Status.Conditions, unikornv1core.ConditionHealthy, healthStatus, healthReason, healthMessage)
 
+	p.logUnhealthyServer(ctx, server, previousHealthReason)
 	p.updateInstanceStatus(server)
 
 	if server.Metadata.ProvisioningStatus != coreapi.ResourceProvisioningStatusProvisioned {

--- a/test/api/fixtures.go
+++ b/test/api/fixtures.go
@@ -185,7 +185,18 @@ func WaitForInstanceActive(client *APIClient, ctx context.Context, config *TestC
 		}
 
 		if instance.Metadata.HealthStatus == coreapi.ResourceHealthStatusError {
-			Fail(fmt.Sprintf("Instance %s entered error health status", instanceID))
+			powerState := "<nil>"
+			if instance.Status.PowerState != nil {
+				powerState = string(*instance.Status.PowerState)
+			}
+
+			Fail(fmt.Sprintf("Instance %s entered error health status (provisioning=%s, powerState=%s, imageID=%s, regionID=%s, networkID=%s)",
+				instanceID,
+				instance.Metadata.ProvisioningStatus,
+				powerState,
+				instance.Spec.ImageId,
+				instance.Status.RegionId,
+				instance.Status.NetworkId))
 		}
 
 		if instance.Status.PowerState == nil {


### PR DESCRIPTION
## Context

The Compute API integration suite hit an intermittent snapshot-launch failure: [test execution](https://nscaleworkspace.slack.com/archives/C0A7HAJFYTC/p1779781730405039)

`Instance b84f7f8f-d3dd-4f10-91cb-9044a0015e79 entered error health status`

I checked the relevant Kubernetes logs first for the failed instance ID, snapshot image ID, and cleanup/source instance ID across:

- `unikorn-compute-instance-controller`
- `unikorn-compute-server`
- `unikorn-region-server-controller`
- `unikorn-region-server`
- cluster events

The logs showed the compute instance reconcile/delete lifecycle and API cleanup activity, but no exact reason for why the backing server health became `error`. The public Compute API response only exposes aggregate `metadata.healthStatus`, so the test failure currently loses the backing-server context needed to debug the next occurrence.

## Change

This PR keeps the scope narrow and only adds diagnostics:

- Log backing region server details when compute mirrors `degraded` or `error` server health onto a compute instance.
- Include aggregate instance state in the integration test failure message when `WaitForInstanceActive` sees `healthStatus=error`.

The new controller log includes instance ID, backing server ID/name, server health/provisioning status, power state, region, network, image, and flavor.

## Expected outcome

This does not attempt to change provisioning behavior. On the next failure, CI/test output plus controller logs should identify the backing region server and its state at the point compute observed unhealthy health, which should make the root cause traceable without broadening the test or controller behavior.

## Verification

- `go test ./pkg/provisioners/managers/instance`
- `go test ./test/api`
- `go test -tags integration ./test/api/suites -ginkgo.dry-run`