### PR TITLE
chore(test): Fix instance not-found error reporting

### DIFF
--- a/test/api/api_client.go
+++ b/test/api/api_client.go
@@ -180,7 +180,7 @@ func (c *APIClient) GetInstance(ctx context.Context, instanceID string) (openapi
 
 		return instance, nil
 	case http.StatusNotFound:
-		return openapi.InstanceRead{}, fmt.Errorf("instance '%s': %w", instanceID, coreclient.ErrResourceNotFound)
+		return openapi.InstanceRead{}, fmt.Errorf("instance '%s' (status: %d): %w", instanceID, resp.StatusCode, coreclient.ErrResourceNotFound)
 	case http.StatusForbidden:
 		return openapi.InstanceRead{}, fmt.Errorf("instance '%s' access denied (status: %d)", instanceID, resp.StatusCode)
 	default:

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -571,7 +571,7 @@ var _ = Describe("Instance Operations", func() {
 				_, err := client.GetInstance(ctx, nonExistentInstanceID)
 
 				Expect(err).To(HaveOccurred(), "Should return error for non-existent instance")
-				Expect(err).To(MatchError(coreclient.ErrResourceNotFound), "Error should indicate HTTP 404 Not Found")
+				Expect(err).To(MatchError(coreclient.ErrResourceNotFound), "Error should indicate resource not found")
 				GinkgoWriter.Printf("Expected HTTP 404 error for non-existent instance: %v\n", err)
 			})
 		})


### PR DESCRIPTION
## Context

The API integration suite reported a false negative in the instance retrieval not-found path:

`Instance Operations When retrieving an instance Given an invalid instance ID [It] should return not found`, [test results](https://nscaleworkspace.slack.com/archives/C0A7HAJFYTC/p1779781423409189)

The test was asserting that the error string contained the numeric HTTP status code (`404`). The compute test client, however, mapped the 404 response to the semantic sentinel error:

`instance 'non-existent-instance-12345': resource not found`

That means the API behavior was returning not found correctly, but the assertion depended on the HTTP status code being embedded in the string representation of the error.

## What's changed

- Preserve the 404 status in the `GetInstance` test-client error message while still wrapping `coreclient.ErrResourceNotFound`.
- Update the failing test assertion description to match what it now checks: the semantic resource-not-found condition.

This keeps the client useful for debugging (`status: 404` is visible) and keeps the test assertion tied to the typed not-found contract rather than a fragile substring.

## Test result after the fix

GitHub Actions run: https://github.com/nscaledev/uni-compute/actions/runs/26442493849

Result: **success**

Relevant details:

- Workflow: `API Tests`
- Branch: `codex/fix-instance-not-found-error`
- Commit: `b027778dc2ff2bfe017fb03dc6acce88adf67abc`
- `API Tests (uat)`: success
- `Run API Tests - All`: success
- Overall run conclusion: success