### PR TITLE
ci: enable Grafana/Loki enrichment for Compute test report analysis

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -84,6 +84,9 @@ jobs:
   API-Tests-Dev:
     name: API Tests (dev)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
     env:
       ENVIRONMENT: dev
@@ -170,6 +173,8 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        enable-grafana-log-enrichment: 'true'
+        grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
 
   find-staging-constellation:
     name: Resolve UAT test ref
@@ -190,6 +195,9 @@ jobs:
     name: API Tests (uat)
     needs: find-staging-constellation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     # Runs only when the resolver produced a UAT checkout ref.
     if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
     env:
@@ -279,3 +287,5 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        enable-grafana-log-enrichment: 'true'
+        grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -174,7 +174,7 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        enable-grafana-log-enrichment: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN != '' && 'true' || 'false' }}
+        enable-grafana-log-enrichment: 'true'
         grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
         grafana-log-lookback: 6h
 
@@ -290,6 +290,6 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        enable-grafana-log-enrichment: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN != '' && 'true' || 'false' }}
+        enable-grafana-log-enrichment: 'true'
         grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
         grafana-log-lookback: 6h

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for the reporting action to open the Teleport Grafana tunnel.
       id-token: write
     if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
     env:
@@ -173,8 +174,9 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        enable-grafana-log-enrichment: 'true'
+        enable-grafana-log-enrichment: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN != '' && 'true' || 'false' }}
         grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+        grafana-log-lookback: 6h
 
   find-staging-constellation:
     name: Resolve UAT test ref
@@ -197,6 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required for the reporting action to open the Teleport Grafana tunnel.
       id-token: write
     # Runs only when the resolver produced a UAT checkout ref.
     if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
@@ -287,5 +290,6 @@ jobs:
         title: 'Compute API Test Results'
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        enable-grafana-log-enrichment: 'true'
+        enable-grafana-log-enrichment: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN != '' && 'true' || 'false' }}
         grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
+        grafana-log-lookback: 6h


### PR DESCRIPTION
## Summary
- Enable Grafana/Loki enrichment in the shared test-results-report action introduced by nscaledev/quality-tooling#10.
- Grant id-token: write so the action can open the Teleport Grafana app tunnel only when backend log queries are planned.
- Keep existing Compute API test reporting and Slack behavior otherwise unchanged.

## Validation
- git diff --check