### PR TITLE
Use public staging constellation action

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -186,7 +186,7 @@ jobs:
       ref: ${{ steps.find.outputs.ref }}
     steps:
     - name: Resolve UAT checkout ref
-      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
+      uses: nscaledev/uni-staging-constellation@main
       id: find
       with:
         service: uni-compute


### PR DESCRIPTION
## Summary
- Switch UAT staging constellation resolution to the public `nscaledev/uni-staging-constellation` action.
- Keep the existing `RELEASES_READ_TOKEN` input and workflow behavior unchanged.

## Validation
- `git diff --check -- .github/workflows/test-api.yaml`
- `actionlint` was run and only reported existing `actions/setup-go@v3` warnings outside this change.