### PR TITLE
feat(ci): add nightly builds, cleanup, and Slack alerting

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -1,0 +1,104 @@
+name: Cleanup Nightlies
+on:
+  schedule:
+  - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      ttl_days:
+        description: 'Delete nightly builds older than this many days'
+        required: false
+        default: '7'
+        type: string
+permissions:
+  contents: write
+  packages: write
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Delete expired nightlies
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TTL_DAYS: ${{ inputs.ttl_days || '7' }}
+      run: |
+        OWNER=$(cut -d'/' -f1 <<< "$GITHUB_REPOSITORY")
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        CHART_PACKAGE_NAME=$(grep '^name:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ -n "${CHART_PACKAGE_NAME}" ]] || {
+          echo "ERROR: could not extract chart name from charts/${CHART_NAME}/Chart.yaml"
+          exit 1
+        }
+        # Read all image names from the Makefile CONTROLLERS variable so this
+        # stays correct if images are added or removed without touching this workflow.
+        readarray -t IMAGE_NAMES < <(awk '/^CONTROLLERS\s*=/{p=1;next} p{line=$0; gsub(/^[[:space:]]+|[[:space:]\\]+$/,"",line); if(line!="")print line; if(!/\\[[:space:]]*$/)p=0}' Makefile)
+        [[ ${#IMAGE_NAMES[@]} -gt 0 && -n "${IMAGE_NAMES[0]}" ]] || {
+          echo "ERROR: could not parse CONTROLLERS from Makefile"
+          exit 1
+        }
+        [[ "${TTL_DAYS}" =~ ^[0-9]+$ ]] || {
+          echo "ERROR: TTL_DAYS must be a positive integer, got: ${TTL_DAYS}"
+          exit 1
+        }
+        CHART_PKG="charts-nightly%2F${CHART_PACKAGE_NAME}"
+
+        CUTOFF=$(date -u -d "${TTL_DAYS} days ago" +%Y%m%d%H%M%S)
+        echo "Cutoff: ${CUTOFF} (TTL: ${TTL_DAYS} days)"
+        echo "Images to clean: ${IMAGE_NAMES[*]}"
+
+        while read -r TAG; do
+          TIMESTAMP=$(sed 's/v0\.0\.0-\([0-9]\{14\}\)-.*/\1/' <<< "$TAG")
+          [[ "$TIMESTAMP" =~ ^[0-9]{14}$ ]] || continue
+          [[ "$TIMESTAMP" < "$CUTOFF" ]] || continue
+
+          CHART_VERSION="${TAG#v}"
+          echo "Expiring ${TAG}"
+          FAILED=0
+
+          # Delete all Docker image package versions for this tag.
+          for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
+            IMAGE_PKG="nightly%2F${IMAGE_NAME}"
+            ID=$(gh api "/orgs/${OWNER}/packages/container/${IMAGE_PKG}/versions" --paginate \
+              --jq ".[] | select((.metadata.container.tags // [])[] == \"${TAG}\") | .id" \
+              2>/dev/null | head -1)
+            if [[ -n "$ID" ]]; then
+              gh api -X DELETE "/orgs/${OWNER}/packages/container/${IMAGE_PKG}/versions/${ID}" \
+                && echo "  ✓ image ${IMAGE_NAME}" || { echo "  ✗ image ${IMAGE_NAME} (will retry next run)"; FAILED=1; }
+            fi
+          done
+
+          # Delete OCI chart package version
+          ID=$(gh api "/orgs/${OWNER}/packages/container/${CHART_PKG}/versions" --paginate \
+            --jq ".[] | select((.metadata.container.tags // [])[] == \"${CHART_VERSION}\") | .id" \
+            2>/dev/null | head -1)
+          if [[ -n "$ID" ]]; then
+            gh api -X DELETE "/orgs/${OWNER}/packages/container/${CHART_PKG}/versions/${ID}" \
+              && echo "  ✓ chart" || { echo "  ✗ chart (will retry next run)"; FAILED=1; }
+          fi
+
+          # Delete git tag last — if any artifact deletion failed above, skip so
+          # the tag remains and the next run retries the failed deletions.
+          if [[ "$FAILED" -ne 0 ]]; then
+            echo "  ↷ skipping git tag deletion — artifact deletion failed, will retry next run"
+            continue
+          fi
+          gh api -X DELETE "/repos/${OWNER}/${REPO}/git/refs/tags/${TAG}" \
+            && echo "  ✓ git tag" || echo "  ✗ git tag"
+
+        done < <(gh api "/repos/${OWNER}/${REPO}/git/refs/tags" --paginate \
+          --jq '.[].ref | select(test("refs/tags/v0\\.0\\.0-"))' \
+          | sed 's|refs/tags/||')
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v2
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": ":red_circle: *Nightly cleanup failed* — `${{ github.repository }}`. I'll be back.\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,93 @@
+name: Nightly
+on:
+  schedule:
+  - cron: '0 2 * * *'
+  workflow_dispatch: {}
+# Queue concurrent runs rather than cancelling them. cancel-in-progress: true
+# would risk killing a run between image/chart publish and tag push, leaving
+# published artifacts with no corresponding tag.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+permissions:
+  contents: write
+  packages: write
+env:
+  REGISTRY: ghcr.io
+jobs:
+  Nightly:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Setup Go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Compute tag
+      run: |
+        TAG="v0.0.0-$(date -u +%Y%m%d%H%M%S)-$(git rev-parse --short=12 HEAD)"
+        CHART_VERSION="${TAG#v}"
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        [[ -d "charts/${CHART_NAME}" ]] || {
+          echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+          exit 1
+        }
+        CHART_PACKAGE_NAME=$(grep '^name:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ -n "${CHART_PACKAGE_NAME}" ]] || {
+          echo "ERROR: could not extract chart name from charts/${CHART_NAME}/Chart.yaml"
+          exit 1
+        }
+        echo "TAG=${TAG}" >> $GITHUB_ENV
+        echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+        echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+        echo "CHART_PACKAGE_NAME=${CHART_PACKAGE_NAME}" >> $GITHUB_ENV
+    - name: Docker Login
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and Push Image
+      # Nightly images are published under ghcr.io/nscaledev/nightly/ to keep
+      # them segregated from official release images at ghcr.io/nscaledev/.
+      run: make touch all images -e RELEASE=1 VERSION="${TAG}" DOCKER_ORG=ghcr.io/nscaledev/nightly
+    - name: Log in to GHCR (Helm)
+      run: |
+        echo "$GITHUB_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update chart dependencies
+      run: helm dependency update "charts/${CHART_NAME}"
+    - name: Package and push chart
+      run: |
+        helm package "charts/${CHART_NAME}" --version "${CHART_VERSION}" --app-version "${CHART_VERSION}"
+        helm push "${CHART_PACKAGE_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/nscaledev/charts-nightly"
+    # Tag is pushed after successful artifact publishes so a failed publish does
+    # not leave a dangling tag pointing at a commit with no artifacts.
+    - name: Push tag
+      run: |
+        git tag "${TAG}"
+        git push origin "${TAG}"
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v2
+      with:
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL_NIGHTLY }}
+        webhook-type: incoming-webhook
+        payload: |
+          {
+            "text": ":red_circle: *Nightly build failed* — `${{ github.repository }}`. I'll be back.\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,11 @@ on:
     branches-ignore:
     - '**'
     tags:
-    - '*'
+      # Exclude nightly pseudo-version tags (v0.0.0-*) precisely rather than
+      # using v[1-9]*, which would silently drop legitimate v0.x.y releases.
+      - 'v*'
+      - '!v0.0.0'
+      - '!v0.0.0-*'
 permissions:
   contents: write
   packages: write
@@ -14,10 +18,53 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - name: checkout
-      uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
+    - name: Validate tag
+      run: |
+        TAG="${GITHUB_REF_NAME}"
+        # Strict semver: vX.Y.Z or vX.Y.Z-pre (alphanumeric, dots, hyphens only).
+        # This rejects build metadata (+), path traversal, sed metacharacters, and
+        # anything else that could corrupt the sed interpolation in the patch step.
+        if [[ ! "${TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
+          echo "ERROR: tag '${TAG}' is not valid semver (expected vX.Y.Z or vX.Y.Z-pre)"
+          exit 1
+        fi
+        if [[ "${TAG}" == "v0.0.0" || "${TAG}" == v0.0.0-* ]]; then
+          echo "ERROR: tags matching v0.0.0 or v0.0.0-* are reserved for nightly builds"
+          exit 1
+        fi
+    - name: Derive chart version
+      run: |
+        CHART_VERSION="${GITHUB_REF_NAME#v}"
+        REPO=$(cut -d'/' -f2 <<< "$GITHUB_REPOSITORY")
+        CHART_NAME=$(sed 's/^uni-//' <<< "$REPO")
+        [[ -d "charts/${CHART_NAME}" ]] || {
+          echo "ERROR: charts/${CHART_NAME} not found — repo name may not match chart directory"
+          exit 1
+        }
+        echo "CHART_VERSION=${CHART_VERSION}" >> $GITHUB_ENV
+        echo "CHART_NAME=${CHART_NAME}" >> $GITHUB_ENV
+    - name: Patch Chart.yaml sentinel
+      run: |
+        # uni-chart-release-action uses `cr package` which reads version directly
+        # from Chart.yaml and has no --version override flag. The sentinel must be
+        # patched on disk before the action runs. Contrast with nightly.yaml, which
+        # bypasses Chart.yaml entirely via `helm package --version`.
+        sed -i "s/^version: 0\.0\.0$/version: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+        sed -i "s/^appVersion: 0\.0\.0$/appVersion: ${CHART_VERSION}/" "charts/${CHART_NAME}/Chart.yaml"
+        PATCHED_VERSION=$(grep '^version:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        PATCHED_APP_VERSION=$(grep '^appVersion:' "charts/${CHART_NAME}/Chart.yaml" | awk '{print $2}')
+        [[ "${PATCHED_VERSION}" == "${CHART_VERSION}" ]] || {
+          echo "ERROR: Chart.yaml version patch failed — sentinel was not present"
+          exit 1
+        }
+        [[ "${PATCHED_APP_VERSION}" == "${CHART_VERSION}" ]] || {
+          echo "ERROR: Chart.yaml appVersion patch failed — sentinel was not present"
+          exit 1
+        }
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
@@ -33,11 +80,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and Push Images
-      run: make touch all images -e RELEASE=1 VERSION=${{ github.ref_name }}
-#    - name: Build SBOMS
-#      run: go run ./hack/sbom
-#    - name: Build Documentation
-#      run: sudo apt -y install wbritish && go run github.com/unikorn-cloud/core/hack/docs -o docs/server-api.md
+      run: make touch all images -e RELEASE=1 VERSION="${{ github.ref_name }}"
     - name: Configure Git
       run: |
         git config user.name "$GITHUB_ACTOR"

--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for deploying Unikorn compute Service
 
 type: application
 
-version: 1.16.4
-appVersion: 1.16.4
+version: 0.0.0
+appVersion: 0.0.0
 
 icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/dark-on-light/icon.png
 


### PR DESCRIPTION
- Add nightly.yaml: daily 2am UTC build that publishes Docker images to
  ghcr.io/nscaledev/nightly/unikorn-compute and Helm charts to
  oci://ghcr.io/nscaledev/charts-nightly, tagged v0.0.0-<timestamp>-<sha>
- Add cleanup.yaml: daily 4am UTC job that deletes nightly builds older
  than TTL_DAYS (default 7); reads CONTROLLERS from the Makefile so all
  Docker images are cleaned, not just the chart image; removes Docker
  image, OCI chart, and git tag in that order so failed artifact
  deletions leave the tag for retry
- Update release.yaml: tighten tag filter to exclude v0.0.0-* nightlies,
  upgrade checkout@v3→v4, add tag validation, derive chart version from
  tag, and patch the Chart.yaml sentinel before running the chart release
  action
- Set Chart.yaml version/appVersion to 0.0.0 sentinel; real versions are
  injected at build time rather than committed
- Use SLACK_WEBHOOK_URL_NIGHTLY secret for Slack failure alerts

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
