### PR TITLE
ci: publish test history via OTLP

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Required for the reporting action to open the Teleport Grafana tunnel.
+      # Required for Teleport-backed Grafana lookup and OTLP collector shipping.
       id-token: write
     if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
     env:
@@ -162,7 +162,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
@@ -172,6 +172,7 @@ jobs:
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
         title: 'Compute API Test Results'
+        test-history-suite: uni-compute-api
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         enable-grafana-log-enrichment: 'true'
@@ -199,7 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Required for the reporting action to open the Teleport Grafana tunnel.
+      # Required for Teleport-backed Grafana lookup and OTLP collector shipping.
       id-token: write
     # Runs only when the resolver produced a UAT checkout ref.
     if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
@@ -278,7 +279,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
@@ -288,6 +289,7 @@ jobs:
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
         title: 'Compute API Test Results'
+        test-history-suite: uni-compute-api
         enable-ai-analysis: 'true'
         claude-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         enable-grafana-log-enrichment: 'true'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -162,7 +162,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json
@@ -279,7 +279,7 @@ jobs:
         max-failures: '5'
 
     - name: Report API Test Results
-      uses: nscaledev/quality-tooling/.github/actions/test-results-report@feat/test-history-post-results
+      uses: nscaledev/quality-tooling/.github/actions/test-results-report@main
       if: ${{ !cancelled() }}
       with:
         test-results-path: test/api/suites/test-results.json


### PR DESCRIPTION
## Summary
- switch API test reporting to the test-history OTLP action branch
- add the uni-compute-api test-history suite name for dev and UAT reports
- keep collector, publish mode, spool upload, and artifact naming on action defaults

Depends on nscaledev/quality-tooling#11 for the action defaults.

## Validation
- ruby YAML parse for .github/workflows/test-api.yaml

## Recent Retest
Small focused run against the latest shared action branch. Slack notifications were disabled where the workflow supports it.

| Suite | Result | Build | Reporter logs | Logs query |
| --- | --- | --- | --- | --- |
| uni-compute API | success | [27155231548](https://github.com/nscaledev/uni-compute/actions/runs/27155231548) | [reporter logs](https://wo11y-grafana-dev.nscale.teleport.sh/explore?orgId=1&schemaVersion=1&panes=%7B%22test-history%22%3A%7B%22datasource%22%3A%22logs-all%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bservice_name%3D%5C%22test-results-report%5C%22%7D+%7C+github_run_id%3D%6027155231548%60%22%2C%22queryType%22%3A%22range%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22logs-all%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D%7D) | <code>{service_name="test-results-report"} &#124; github_run_id=`27155231548`</code> |
