### PR TITLE
feat: propagate provider provisioning status to instances

### DIFF
--- a/charts/compute/crds/compute.unikorn-cloud.org_computeinstances.yaml
+++ b/charts/compute/crds/compute.unikorn-cloud.org_computeinstances.yaml
@@ -187,6 +187,8 @@ spec:
                 description: PowerState is the current status of the machine.
                 enum:
                 - Pending
+                - Queued
+                - Building
                 - Running
                 - Stopping
                 - Stopped

--- a/pkg/apis/unikorn/v1alpha1/README.md
+++ b/pkg/apis/unikorn/v1alpha1/README.md
@@ -20,8 +20,9 @@ root, not for the hidden execution primitive.
   security groups, and allowed source addresses
 - optional SSH certificate authority linkage
 - optional cloud-init user data
-- projected runtime status such as IP addresses, MAC address, power state, and
-  health conditions
+- projected runtime status such as IP addresses, MAC address, power state
+  (which carries the full lifecycle Phase including baremetal `Queued` /
+  `Building` from region), and health conditions
 
 The object also carries org/project/region/network labels and delegated
 principal metadata through shared helpers outside this package.
@@ -35,7 +36,11 @@ principal metadata through shared helpers outside this package.
 - `Pause` is a real reconciliation guard rail. A paused instance should stop
   compute-side reconciliation without changing the stored desired state.
 - Status is mostly projected truth from the backing `region.Server`, not an
-  independently reconciled compute-owned runtime source of truth.
+  independently reconciled compute-owned runtime source of truth. Power state
+  (live Phase) flows through unchanged from region, including `Queued` and
+  `Building` for baremetal lifecycles. Once provisioning status reaches
+  `provisioned`, power state is the live readiness signal: clients should
+  treat `Running` (not `provisioned`) as ready-to-use.
 - `PublicIPEnabled()` is part of the accounting contract: quota allocation logic
   derives floating-IP usage from this persisted intent.
 

--- a/pkg/provisioners/managers/instance/README.md
+++ b/pkg/provisioners/managers/instance/README.md
@@ -20,7 +20,8 @@ where that contract is translated into the hidden execution primitive.
 - Create and update requests sent to region always carry the reserved instance
   tag so later lookup and reverse mapping can find the server again.
 - Instance status is projection-only here: IP addresses, MAC address, power
-  state, and health are copied from the server response.
+  state (lifecycle Phase, including Queued/Building for baremetal), and health
+  are copied from the server response.
 - Deprovision is two-stage:
   delete the backing server first, then release the identity allocation record
   only after the server is gone.
@@ -63,7 +64,9 @@ removed from the rebuild heuristic.
 - The region client is not cached and the code already notes token/cache churn
   risk during busy periods.
 - This package depends on region to be the truth source for provisioning
-  progress and health. Compute does not independently observe provider state.
+  progress and health. Compute does not independently observe provider state;
+  when region distinguishes queued baremetal servers from active provisioning,
+  this package only persists and re-exposes that region-derived metadata.
 
 ## TODO
 

--- a/pkg/provisioners/managers/instance/export_test.go
+++ b/pkg/provisioners/managers/instance/export_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	unikornv1 "github.com/unikorn-cloud/compute/pkg/apis/unikorn/v1alpha1"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 )
 
@@ -47,4 +48,8 @@ func (p *Provisioner) CreateOrUpdateServer(ctx context.Context, region regionapi
 
 func (p *Provisioner) UpdateInstanceStatus(server *regionapi.ServerV2Response) {
 	p.updateInstanceStatus(server)
+}
+
+func ConvertPowerState(in *regionapi.InstanceLifecyclePhase) *regionv1.InstanceLifecyclePhase {
+	return convertPowerState(in)
 }

--- a/pkg/provisioners/managers/instance/provisioner.go
+++ b/pkg/provisioners/managers/instance/provisioner.go
@@ -296,6 +296,10 @@ func convertPowerState(in *regionapi.InstanceLifecyclePhase) *regionv1.InstanceL
 
 	//nolint:exhaustive
 	switch *in {
+	case regionapi.InstanceLifecyclePhaseQueued:
+		return ptr.To(regionv1.InstanceLifecyclePhaseQueued)
+	case regionapi.InstanceLifecyclePhaseBuilding:
+		return ptr.To(regionv1.InstanceLifecyclePhaseBuilding)
 	case regionapi.InstanceLifecyclePhaseRunning:
 		return ptr.To(regionv1.InstanceLifecyclePhaseRunning)
 	case regionapi.InstanceLifecyclePhaseStopping:

--- a/pkg/provisioners/managers/instance/provisioner.go
+++ b/pkg/provisioners/managers/instance/provisioner.go
@@ -294,8 +294,13 @@ func convertPowerState(in *regionapi.InstanceLifecyclePhase) *regionv1.InstanceL
 		return nil
 	}
 
-	//nolint:exhaustive
+	// Unknown phases stay nil so future region additions surface
+	// immediately rather than being silently relabelled as Pending. The
+	// handler-side convertPowerState in pkg/server/handler/instance/client.go
+	// uses the same fall-through-to-nil convention; keep them in lockstep.
 	switch *in {
+	case regionapi.InstanceLifecyclePhasePending:
+		return ptr.To(regionv1.InstanceLifecyclePhasePending)
 	case regionapi.InstanceLifecyclePhaseQueued:
 		return ptr.To(regionv1.InstanceLifecyclePhaseQueued)
 	case regionapi.InstanceLifecyclePhaseBuilding:
@@ -306,9 +311,9 @@ func convertPowerState(in *regionapi.InstanceLifecyclePhase) *regionv1.InstanceL
 		return ptr.To(regionv1.InstanceLifecyclePhaseStopping)
 	case regionapi.InstanceLifecyclePhaseStopped:
 		return ptr.To(regionv1.InstanceLifecyclePhaseStopped)
-	default:
-		return ptr.To(regionv1.InstanceLifecyclePhasePending)
 	}
+
+	return nil
 }
 
 func convertHealthStatusCondition(in coreapi.ResourceHealthStatus) (corev1.ConditionStatus, unikornv1core.ConditionReason, string) {

--- a/pkg/provisioners/managers/instance/provisioner_test.go
+++ b/pkg/provisioners/managers/instance/provisioner_test.go
@@ -28,6 +28,7 @@ import (
 	unikornv1core "github.com/unikorn-cloud/core/pkg/apis/unikorn/v1alpha1"
 	coreconstants "github.com/unikorn-cloud/core/pkg/constants"
 	coreapi "github.com/unikorn-cloud/core/pkg/openapi"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	regionconstants "github.com/unikorn-cloud/region/pkg/constants"
 	regionids "github.com/unikorn-cloud/region/pkg/ids"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
@@ -216,4 +217,42 @@ func TestUpdateInstanceStatusCopiesMACAddress(t *testing.T) {
 	require.Equal(t, server.Status.MacAddress, instanceObject.Status.MACAddress)
 	require.NotNil(t, instanceObject.Status.PowerState)
 	assert.Equal(t, "Running", string(*instanceObject.Status.PowerState))
+}
+
+// TestConvertPowerStateRoundTrip verifies every known region phase round-trips
+// from the regionapi enum (API surface) to the regionv1 enum (CR surface).
+// Unknown phases must return nil — see the comment in convertPowerState for
+// the rationale.
+func TestConvertPowerStateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   *regionapi.InstanceLifecyclePhase
+		want *regionv1.InstanceLifecyclePhase
+	}{
+		{name: "nil input", in: nil, want: nil},
+		{name: "pending", in: ptr.To(regionapi.InstanceLifecyclePhasePending), want: ptr.To(regionv1.InstanceLifecyclePhasePending)},
+		{name: "queued", in: ptr.To(regionapi.InstanceLifecyclePhaseQueued), want: ptr.To(regionv1.InstanceLifecyclePhaseQueued)},
+		{name: "building", in: ptr.To(regionapi.InstanceLifecyclePhaseBuilding), want: ptr.To(regionv1.InstanceLifecyclePhaseBuilding)},
+		{name: "running", in: ptr.To(regionapi.InstanceLifecyclePhaseRunning), want: ptr.To(regionv1.InstanceLifecyclePhaseRunning)},
+		{name: "stopping", in: ptr.To(regionapi.InstanceLifecyclePhaseStopping), want: ptr.To(regionv1.InstanceLifecyclePhaseStopping)},
+		{name: "stopped", in: ptr.To(regionapi.InstanceLifecyclePhaseStopped), want: ptr.To(regionv1.InstanceLifecyclePhaseStopped)},
+		{name: "unknown future phase falls through to nil", in: ptr.To(regionapi.InstanceLifecyclePhase("FutureUnknown")), want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := instance.ConvertPowerState(tc.in)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.want, *got)
+		})
+	}
 }

--- a/pkg/server/handler/instance/README.md
+++ b/pkg/server/handler/instance/README.md
@@ -81,6 +81,19 @@ server lookup by:
 That keeps the public API centered on `Instance`, but it also means the server
 link is reconstructed rather than stored explicitly.
 
+## Phase Projection
+
+`convertPowerState` projects the region-owned `Server.Status.PowerState`
+(a `regionv1.InstanceLifecyclePhase` on the persisted `ComputeInstance`) into
+the public API as `status.powerState`. The round-trip is lossless for known
+phases — `Pending`, `Queued`, `Building`, `Running`, `Stopping`, `Stopped` — and
+intentionally drops unknown values to `nil` rather than collapsing them to
+`Pending`. This keeps the API honest: if region adds a new phase before compute
+learns about it, callers see no `powerState` rather than a misleading `Pending`,
+which surfaces the gap immediately. The provisioner-side `convertPowerState`
+follows the same rule so the controller and handler agree on what "unknown"
+means.
+
 ## Caveats
 
 - The instance-to-server link is implicit and tag-based. That is flexible, but

--- a/pkg/server/handler/instance/client.go
+++ b/pkg/server/handler/instance/client.go
@@ -145,12 +145,12 @@ func convertPowerState(in *regionv1.InstanceLifecyclePhase) *regionapi.InstanceL
 	}
 
 	switch *in {
+	case regionv1.InstanceLifecyclePhasePending:
+		return ptr.To(regionapi.InstanceLifecyclePhasePending)
 	case regionv1.InstanceLifecyclePhaseQueued:
 		return ptr.To(regionapi.InstanceLifecyclePhaseQueued)
 	case regionv1.InstanceLifecyclePhaseBuilding:
 		return ptr.To(regionapi.InstanceLifecyclePhaseBuilding)
-	case regionv1.InstanceLifecyclePhasePending:
-		return ptr.To(regionapi.InstanceLifecyclePhasePending)
 	case regionv1.InstanceLifecyclePhaseRunning:
 		return ptr.To(regionapi.InstanceLifecyclePhaseRunning)
 	case regionv1.InstanceLifecyclePhaseStopping:

--- a/pkg/server/handler/instance/client_test.go
+++ b/pkg/server/handler/instance/client_test.go
@@ -35,6 +35,7 @@ import (
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	identitymock "github.com/unikorn-cloud/identity/pkg/openapi/mock"
 	"github.com/unikorn-cloud/identity/pkg/rbac"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	regionconstants "github.com/unikorn-cloud/region/pkg/constants"
 	regionids "github.com/unikorn-cloud/region/pkg/ids"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
@@ -374,4 +375,44 @@ func TestValidateSSHCertificateAuthorityScopeOrganizationMismatch(t *testing.T) 
 	}, identityids.MustParseOrganizationID(organizationID), identityids.MustParseProjectID(projectID))
 	require.Error(t, err)
 	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422, got: %v", err)
+}
+
+// TestConvertPowerStateRoundTrip verifies the handler-side projection from
+// the persisted regionv1 phase enum back into the regionapi phase enum
+// returned to API clients. Unknown values drop to nil; this is the
+// design choice documented in convertPowerState and mirrored by the
+// provisioner-side conversion.
+func TestConvertPowerStateRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   *regionv1.InstanceLifecyclePhase
+		want *regionapi.InstanceLifecyclePhase
+	}{
+		{name: "nil input", in: nil, want: nil},
+		{name: "empty string sentinel", in: ptr.To(regionv1.InstanceLifecyclePhase("")), want: nil},
+		{name: "pending", in: ptr.To(regionv1.InstanceLifecyclePhasePending), want: ptr.To(regionapi.InstanceLifecyclePhasePending)},
+		{name: "queued", in: ptr.To(regionv1.InstanceLifecyclePhaseQueued), want: ptr.To(regionapi.InstanceLifecyclePhaseQueued)},
+		{name: "building", in: ptr.To(regionv1.InstanceLifecyclePhaseBuilding), want: ptr.To(regionapi.InstanceLifecyclePhaseBuilding)},
+		{name: "running", in: ptr.To(regionv1.InstanceLifecyclePhaseRunning), want: ptr.To(regionapi.InstanceLifecyclePhaseRunning)},
+		{name: "stopping", in: ptr.To(regionv1.InstanceLifecyclePhaseStopping), want: ptr.To(regionapi.InstanceLifecyclePhaseStopping)},
+		{name: "stopped", in: ptr.To(regionv1.InstanceLifecyclePhaseStopped), want: ptr.To(regionapi.InstanceLifecyclePhaseStopped)},
+		{name: "unknown future phase falls through to nil", in: ptr.To(regionv1.InstanceLifecyclePhase("FutureUnknown")), want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := instance.ConvertPowerState(tc.in)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.want, *got)
+		})
+	}
 }

--- a/pkg/server/handler/instance/export_test.go
+++ b/pkg/server/handler/instance/export_test.go
@@ -21,6 +21,7 @@ import (
 	computeapi "github.com/unikorn-cloud/compute/pkg/openapi"
 	identityids "github.com/unikorn-cloud/identity/pkg/ids"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
+	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 )
 
@@ -38,4 +39,8 @@ func ValidateSSHCertificateAuthorityScope(resource *regionapi.SshCertificateAuth
 
 func Convert(resource *computev1.ComputeInstance) (*computeapi.InstanceRead, error) {
 	return convert(resource)
+}
+
+func ConvertPowerState(in *regionv1.InstanceLifecyclePhase) *regionapi.InstanceLifecyclePhase {
+	return convertPowerState(in)
 }


### PR DESCRIPTION
## Summary

Drop the `ProviderProvisioningStatus` override field from
`ComputeInstance.Status` and the mirror projection in `updateInstanceStatus`.
Compute now relies on region's extended `InstanceLifecyclePhase` (gaining
`Queued` and `Building` in nscaledev/uni-region#561) flowing through the
existing `Status.PowerState` projection, and both `convertPowerState`
switches handle the new values explicitly.

## Why

Per spjmurray's follow-up review on nscaledev/uni-region#561, baremetal
lifecycle distinctions belong on `Phase` (monitor-owned, live), not on
`provisioning_status` (provisioner-owned). Compute mirrors region's
decision: drop the override, propagate Phase. See the region PR for
the full design rationale.

## UX contract change

API consumers should treat `PowerState=Running` as the readiness signal,
not `provisioning_status=provisioned`. uni-ui (nscaledev/uni-ui#392) and
nscale-cli need a follow-up to track this.

## What's in this PR

- `ea8590f` — README + go.mod alignment for the already-landed
  ProviderProvisioningStatus removal (functional drop was in `cf24e26`
  on main).
- `0063f8f` — bump region dep to the HEAD of nscaledev/uni-region#561
  (pseudo-version `v1.17.1-0.20260616151333-afe8bce67baa`), which exports
  the `Queued` / `Building` enum constants.
- `9ced39b` — map `Queued` and `Building` through both `convertPowerState`
  switches (server handler and provisioner) so the new phases land in
  `ComputeInstance.Status.PowerState` and are served from the compute API.
- `513ab9e` — align both `convertPowerState` functions to fall through to
  `nil` on unknown phases (dropping the lossy `default → Pending` that
  silently relabelled future region additions); table-driven tests for
  both directions covering all six known phases plus nil / empty / unknown
  inputs; new "Phase Projection" section in the handler README.

## Stack / merge order

1. nscaledev/uni-region#561 — must merge first; once tagged, the
   pseudo-version pin in `go.mod` here should be bumped to the released
   version before this PR lands.
2. This PR.
3. nscaledev/uni-ui#392 — UI follow-up that surfaces `Queued` / `Building`
   chips; safe to land any time after this one.

## Dependencies

- Closes dependency on nscaledev/uni-core#305 (now closed); bumps core
  to released `v1.17.1`.