### PR TITLE
Validate service version as semver in integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/unikorn-cloud/compute
 go 1.25.8
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-chi/chi/v5 v5.2.4
 	github.com/google/uuid v1.6.0
@@ -24,7 +25,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/brunoga/deep v1.2.4 // indirect

--- a/test/api/suites/version_test.go
+++ b/test/api/suites/version_test.go
@@ -22,6 +22,8 @@ package suites
 import (
 	"net/http"
 
+	"github.com/Masterminds/semver/v3"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -36,11 +38,11 @@ var _ = Describe("Service Version", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(version.Name).To(HavePrefix("unikorn-compute-"))
-				// 0.0.0 is the Makefile default for unstamped local builds.
-				Expect(version.Version).To(SatisfyAny(
-					Equal("0.0.0"),
-					MatchRegexp(`^v\d+\.\d+\.\d+$`),
-				))
+				// Releases are stamped with a semver tag, dev builds with a Go
+				// pseudo-version (e.g. v0.0.0-20260624115013-59dc5a97ce0b), and
+				// unstamped local builds default to 0.0.0; all are valid semver.
+				_, semverErr := semver.NewVersion(version.Version)
+				Expect(semverErr).NotTo(HaveOccurred(), "service version %q is not valid semver", version.Version)
 
 				GinkgoWriter.Printf("Compute service version: %s %s\n", version.Name, version.Version)
 			})


### PR DESCRIPTION
The version assertion only accepted "0.0.0" or a strict "vX.Y.Z" tag, so
nightly builds stamped with a Go pseudo-version
(e.g. v0.0.0-20260624115013-59dc5a97ce0b) failed the check even though a
pseudo-version is valid semver.

Parse the reported version with the Masterminds semver library instead of
matching a narrow regex. This accepts release tags, pseudo-versions and the
0.0.0 local-build default while still rejecting genuinely malformed strings.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
