### PR TITLE
Resolve API test refs from deployed versions

### DIFF
--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -87,6 +87,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
+      version: ${{ steps.find.outputs.version }}
     steps:
     - name: Resolve Dev checkout ref
       uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
@@ -194,6 +195,7 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: dev
+        deployed-version: ${{ needs.find-dev-deployed-version.outputs.version || needs.find-dev-deployed-version.outputs.ref }}
         title: 'Compute API Test Results'
         test-history-suite: uni-compute-api
         enable-ai-analysis: 'true'
@@ -208,6 +210,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
     outputs:
       ref: ${{ steps.find.outputs.ref }}
+      version: ${{ steps.find.outputs.version }}
     steps:
     - name: Resolve UAT checkout ref
       uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
@@ -316,6 +319,7 @@ jobs:
         slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
         send-slack: ${{ github.event.inputs.skip_slack_notifications != 'true' && 'true' || 'false' }}
         environment: uat
+        deployed-version: ${{ needs.find-uat-deployed-version.outputs.version || needs.find-uat-deployed-version.outputs.ref }}
         title: 'Compute API Test Results'
         test-history-suite: uni-compute-api
         enable-ai-analysis: 'true'

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -81,14 +81,35 @@ jobs:
         - **Network ID Override:** \`$NETWORK_ID_OVERRIDE\`
         EOF
 
+  find-dev-deployed-version:
+    name: Resolve Dev test ref
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
+    outputs:
+      ref: ${{ steps.find.outputs.ref }}
+    steps:
+    - name: Resolve Dev checkout ref
+      uses: nscaledev/quality-tooling/.github/actions/uni-find-staging-constellation@main
+      id: find
+      with:
+        service: uni-compute
+        releases-read-token: ${{ secrets.RELEASES_READ_TOKEN }}
+        use-version-api: true
+        version-api-url: ${{ vars.DEV_API_BASE_URL }}/api/version
+        version-api-token: ${{ secrets.DEV_API_AUTH_TOKEN }}
+        fallback-to-constellation: false
+        summary-title: Dev API Test Version
+
   API-Tests-Dev:
     name: API Tests (dev)
+    needs: find-dev-deployed-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
       # Required for Teleport-backed Grafana lookup and OTLP collector shipping.
       id-token: write
-    if: github.event_name == 'schedule' || github.event.inputs.run_dev == 'true'
+    # Runs only when the resolver produced a Dev checkout ref.
+    if: (github.event_name == 'schedule' || github.event.inputs.run_dev == 'true') && needs.find-dev-deployed-version.outputs.ref != ''
     env:
       ENVIRONMENT: dev
       API_BASE_URL: ${{ vars.DEV_API_BASE_URL }}
@@ -116,6 +137,8 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.find-dev-deployed-version.outputs.ref }}
 
     - name: Setup Go
       uses: actions/setup-go@v3
@@ -179,7 +202,7 @@ jobs:
         grafana-service-account-token: ${{ secrets.GRAFANA_SERVICE_ACCOUNT_TOKEN }}
         grafana-log-lookback: 6h
 
-  find-staging-constellation:
+  find-uat-deployed-version:
     name: Resolve UAT test ref
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event.inputs.run_uat == 'true'
@@ -193,17 +216,22 @@ jobs:
         service: uni-compute
         releases-read-token: ${{ secrets.RELEASES_READ_TOKEN }}
         use-staging-constellation: ${{ github.event_name == 'schedule' || github.event.inputs.use_staging_constellation != 'false' }}
+        use-version-api: true
+        version-api-url: ${{ vars.UAT_API_BASE_URL }}/api/version
+        version-api-token: ${{ secrets.UAT_API_AUTH_TOKEN }}
+        fallback-to-constellation: false
+        summary-title: UAT API Test Version
 
   API-Tests-UAT:
     name: API Tests (uat)
-    needs: find-staging-constellation
+    needs: find-uat-deployed-version
     runs-on: ubuntu-latest
     permissions:
       contents: read
       # Required for Teleport-backed Grafana lookup and OTLP collector shipping.
       id-token: write
     # Runs only when the resolver produced a UAT checkout ref.
-    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-staging-constellation.outputs.ref != ''
+    if: (github.event_name == 'schedule' || github.event.inputs.run_uat == 'true') && needs.find-uat-deployed-version.outputs.ref != ''
     env:
       ENVIRONMENT: uat
       API_BASE_URL: ${{ vars.UAT_API_BASE_URL }}
@@ -232,7 +260,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ needs.find-staging-constellation.outputs.ref }}
+        ref: ${{ needs.find-uat-deployed-version.outputs.ref }}
 
     - name: Setup Go
       uses: actions/setup-go@v3


### PR DESCRIPTION
## Summary

Follows the `uni-region` API test checkout pattern from nscaledev/uni-region#573.

- resolves the Dev API test checkout ref from the deployed `uni-compute` `/api/version`
- resolves the UAT API test checkout ref from the deployed `uni-compute` `/api/version`
- keeps UAT staging constellation selection available, but disables constellation fallback when the version API lookup is enabled
- checks out the resolved ref before running API tests
- passes the resolved deployed version/ref to `test-results-report` for Slack context
- lets the shared action write the resolved version/ref summary into the job summary

## Why

API tests should run from the same component version that is deployed in the target environment. This avoids failures caused by testing expectations from one ref against a different deployed service version.

## Validation

- `git diff --check`
- YAML parse check for `.github/workflows/test-api.yaml`
- Focused Dev/UAT API workflow run with Slack disabled: https://github.com/nscaledev/uni-compute/actions/runs/28178264741
