### PR TITLE
Deny cross-network security group references on instance create and update

### DIFF
--- a/pkg/server/handler/instance/README.md
+++ b/pkg/server/handler/instance/README.md
@@ -26,8 +26,19 @@ key retrieval, or snapshotting are requested.
   impersonated access rather than trusting a caller-supplied ownership claim.
 - Flavor and image must both be visible in the chosen region and must be
   mutually compatible for architecture, disk size, and virtualization mode.
-- SSH CA references must stay inside the same organization and project as the
-  instance.
+- Referenced resources must stay inside the instance's scope, rejected at the API
+  edge with HTTP 422 on both create and update. Fetching a reference from region
+  only proves the caller MAY see it — a caller authorized across several tenancies
+  could otherwise attach a resource from another tenancy — so an explicit scope
+  check is applied on top:
+  - a referenced security group must belong to the same **network** as the
+    instance (`status.networkId`). A network belongs to exactly one identity (one
+    underlying OpenStack project), which belongs to one organization and project,
+    so same-network is the natural granularity that closes the cross-tenancy hole
+    and matches what OpenStack permits. Region enforces the identical rule against
+    the same field, so it is uniform across both services.
+  - a referenced SSH CA (which is not network-scoped) must share the instance's
+    organization and project.
 - User data is validated more strictly when an SSH CA is attached because
   managed user-data injection depends on recognized cloud-init formats.
 - Instance names are unique per network: the Kubernetes resource name is derived

--- a/pkg/server/handler/instance/client.go
+++ b/pkg/server/handler/instance/client.go
@@ -345,7 +345,7 @@ func (c *Client) validateCreateRequest(ctx context.Context, request *computeapi.
 		return nil, err
 	}
 
-	if err := c.validateSecurityGroups(ctx, request.Spec.Networking); err != nil {
+	if err := c.validateSecurityGroups(principal.NewImpersonateContext(ctx), request.Spec.NetworkId, request.Spec.Networking); err != nil {
 		return nil, err
 	}
 
@@ -360,8 +360,8 @@ func (c *Client) validateCreateRequest(ctx context.Context, request *computeapi.
 	return flavor, nil
 }
 
-func (c *Client) validateUpdateRequest(ctx context.Context, request *computeapi.InstanceUpdate, organizationID identityids.OrganizationID, projectID identityids.ProjectID) error {
-	if err := c.validateSecurityGroups(ctx, request.Spec.Networking); err != nil {
+func (c *Client) validateUpdateRequest(ctx context.Context, request *computeapi.InstanceUpdate, organizationID identityids.OrganizationID, projectID identityids.ProjectID, networkID regionids.NetworkID) error {
+	if err := c.validateSecurityGroups(principal.NewImpersonateContext(ctx), networkID, request.Spec.Networking); err != nil {
 		return err
 	}
 
@@ -546,7 +546,7 @@ func (c *Client) getImage(ctx context.Context, organizationID identityids.Organi
 	return &resources[index], nil
 }
 
-func (c *Client) validateSecurityGroups(ctx context.Context, networking *computeapi.InstanceNetworking) error {
+func (c *Client) validateSecurityGroups(ctx context.Context, networkID regionids.NetworkID, networking *computeapi.InstanceNetworking) error {
 	if networking == nil || networking.SecurityGroups == nil {
 		return nil
 	}
@@ -559,9 +559,31 @@ func (c *Client) validateSecurityGroups(ctx context.Context, networking *compute
 			return err
 		}
 
-		if _, err := region.GetSecurityGroup(ctx, c.region, securityGroupID); err != nil {
+		securityGroup, err := region.GetSecurityGroup(ctx, c.region, securityGroupID)
+		if err != nil {
 			return err
 		}
+
+		if err := validateSecurityGroupNetwork(securityGroup, networkID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateSecurityGroupNetwork denies a security group reference that belongs to a
+// different network. A security group fetched from the region service only proves the
+// caller MAY see it, which a caller authorized across several tenancies satisfies even
+// for a security group in another network. A network belongs to exactly one identity
+// (one underlying OpenStack project), which belongs to one organization and project,
+// so requiring the security group to share the instance's network closes the
+// cross-tenancy hole at its natural granularity and matches what OpenStack permits. The
+// owning network is the read model's status.networkId, the same field region enforces
+// against, so the identical rule applies across both services.
+func validateSecurityGroupNetwork(resource *regionapi.SecurityGroupV2Read, networkID regionids.NetworkID) error {
+	if resource.Status.NetworkId != networkID.String() {
+		return errors.HTTPUnprocessableContent("a referenced security group must belong to the same network as the instance")
 	}
 
 	return nil
@@ -868,7 +890,7 @@ func (c *Client) Update(ctx context.Context, instanceID computeids.InstanceID, r
 		return nil, err
 	}
 
-	if err := c.validateUpdateRequest(ctx, request, organizationID, projectID); err != nil {
+	if err := c.validateUpdateRequest(ctx, request, organizationID, projectID, networkID); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/handler/instance/client_test.go
+++ b/pkg/server/handler/instance/client_test.go
@@ -377,6 +377,31 @@ func TestValidateSSHCertificateAuthorityScopeOrganizationMismatch(t *testing.T) 
 	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422, got: %v", err)
 }
 
+func TestValidateSecurityGroupNetwork(t *testing.T) {
+	t.Parallel()
+
+	networkID := regionids.MustParseNetworkID("a1b2c3d4-e5f6-4789-8abc-def012345678")
+
+	err := instance.ValidateSecurityGroupNetwork(&regionapi.SecurityGroupV2Read{
+		Status: regionapi.SecurityGroupV2Status{
+			NetworkId: networkID.String(),
+		},
+	}, networkID)
+	require.NoError(t, err)
+}
+
+func TestValidateSecurityGroupNetworkMismatch(t *testing.T) {
+	t.Parallel()
+
+	err := instance.ValidateSecurityGroupNetwork(&regionapi.SecurityGroupV2Read{
+		Status: regionapi.SecurityGroupV2Status{
+			NetworkId: "11111111-1111-4111-a111-111111111111",
+		},
+	}, regionids.MustParseNetworkID("a1b2c3d4-e5f6-4789-8abc-def012345678"))
+	require.Error(t, err)
+	require.True(t, coreerrors.IsUnprocessableContent(err), "expected 422, got: %v", err)
+}
+
 // TestConvertPowerStateRoundTrip verifies the handler-side projection from
 // the persisted regionv1 phase enum back into the regionapi phase enum
 // returned to API clients. Unknown values drop to nil; this is the

--- a/pkg/server/handler/instance/export_test.go
+++ b/pkg/server/handler/instance/export_test.go
@@ -22,6 +22,7 @@ import (
 	identityids "github.com/unikorn-cloud/identity/pkg/ids"
 	identityapi "github.com/unikorn-cloud/identity/pkg/openapi"
 	regionv1 "github.com/unikorn-cloud/region/pkg/apis/unikorn/v1alpha1"
+	regionids "github.com/unikorn-cloud/region/pkg/ids"
 	regionapi "github.com/unikorn-cloud/region/pkg/openapi"
 )
 
@@ -35,6 +36,10 @@ func ValidateUserDataForSSHCertificateAuthority(sshCertificateAuthorityID *regio
 
 func ValidateSSHCertificateAuthorityScope(resource *regionapi.SshCertificateAuthorityV2Response, organizationID identityids.OrganizationID, projectID identityids.ProjectID) error {
 	return validateSSHCertificateAuthorityScope(resource, organizationID, projectID)
+}
+
+func ValidateSecurityGroupNetwork(resource *regionapi.SecurityGroupV2Read, networkID regionids.NetworkID) error {
+	return validateSecurityGroupNetwork(resource, networkID)
 }
 
 func Convert(resource *computev1.ComputeInstance) (*computeapi.InstanceRead, error) {


### PR DESCRIPTION
An instance could reference a security group belonging to a different network —
and therefore a different identity and underlying OpenStack project — than the
instance itself. The handler fetched each referenced security group from the
region service purely to confirm it existed; that read only proves the caller may
see the resource, which a caller authorized across several tenancies satisfies
even for a security group in another network, so nothing kept the reference
within the instance's own network.

Add validateSecurityGroupNetwork and validate every referenced security group
against the instance's network on both create and update (security groups are
mutable). A network belongs to exactly one identity (one OpenStack project), so
same-network is the natural granularity that closes the cross-tenancy hole and
matches what OpenStack permits. The owning network is the read model's
status.networkId, the same field region enforces against, so the identical rule
applies across both services. Mismatches are rejected at the API edge with HTTP
422.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
