### PR TITLE
Port Auth0 compute access tests

### DIFF
--- a/test/api/config.go
+++ b/test/api/config.go
@@ -27,6 +27,8 @@ import (
 type TestConfig struct {
 	coreconfig.BaseConfig
 	RegionBaseURL        string
+	AuditToken           string
+	PublicAdminToken     string
 	OrgID                string
 	ProjectID            string
 	RegionID             string
@@ -66,7 +68,7 @@ func LoadTestConfig() (*TestConfig, error) {
 	config := &TestConfig{
 		BaseConfig: coreconfig.BaseConfig{
 			BaseURL:         v.GetString("API_BASE_URL"),
-			AuthToken:       v.GetString("API_AUTH_TOKEN"),
+			AuthToken:       firstNonEmpty(v.GetString("API_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_ADMIN")),
 			RequestTimeout:  coreconfig.GetDurationFromViper(v, "REQUEST_TIMEOUT", 30*time.Second),
 			TestTimeout:     coreconfig.GetDurationFromViper(v, "TEST_TIMEOUT", 20*time.Minute),
 			SkipIntegration: v.GetBool("SKIP_INTEGRATION"),
@@ -75,6 +77,8 @@ func LoadTestConfig() (*TestConfig, error) {
 			LogResponses:    v.GetBool("LOG_RESPONSES"),
 		},
 		RegionBaseURL:        v.GetString("REGION_BASE_URL"),
+		AuditToken:           firstNonEmpty(v.GetString("AUDIT_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_AUDIT")),
+		PublicAdminToken:     firstNonEmpty(v.GetString("PUBLIC_ADMIN_AUTH_TOKEN"), v.GetString("SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN")),
 		OrgID:                v.GetString("TEST_ORG_ID"),
 		ProjectID:            v.GetString("TEST_PROJECT_ID"),
 		RegionID:             v.GetString("TEST_REGION_ID"),
@@ -101,4 +105,14 @@ func LoadTestConfig() (*TestConfig, error) {
 	}
 
 	return config, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
 }

--- a/test/api/suites/instance_operations_test.go
+++ b/test/api/suites/instance_operations_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package suites
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -73,6 +74,46 @@ var _ = Describe("Instance Operations", func() {
 				}
 
 				GinkgoWriter.Printf("Found instance %s in list with status provisioned\n", instanceID)
+			})
+		})
+
+		Describe("Given an audit token", func() {
+			It("should list instances as read-only", func() {
+				if config.AuditToken == "" {
+					Skip("AUDIT_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_AUDIT must be set by integration fixtures")
+				}
+
+				auditConfig := *config
+				auditConfig.AuthToken = config.AuditToken
+				auditClient := api.NewAPIClientWithConfig(&auditConfig)
+
+				instances, err := auditClient.ListInstances(ctx, config.OrgID, config.ProjectID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(instances).NotTo(BeEmpty())
+			})
+		})
+
+		Describe("Given a public-admin token for a private organization", func() {
+			It("should not expose private organization instances", func() {
+				if config.PublicAdminToken == "" {
+					Skip("PUBLIC_ADMIN_AUTH_TOKEN or SERVICE_TOKEN_PRIVATE_PUBLIC_ADMIN must be set by integration fixtures")
+				}
+
+				publicAdminConfig := *config
+				publicAdminConfig.AuthToken = config.PublicAdminToken
+				publicAdminClient := api.NewAPIClientWithConfig(&publicAdminConfig)
+
+				path := api.NewEndpoints().ListInstances(config.OrgID, config.ProjectID)
+				resp, respBody, err := publicAdminClient.DoRequest(ctx, http.MethodGet, path, nil, 0)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp).NotTo(BeNil())
+				Expect(resp.StatusCode).To(BeElementOf(http.StatusOK, http.StatusForbidden))
+
+				if resp.StatusCode == http.StatusOK {
+					var instances []openapi.InstanceRead
+					Expect(json.Unmarshal(respBody, &instances)).To(Succeed())
+					Expect(instances).To(BeEmpty())
+				}
 			})
 		})
 	})


### PR DESCRIPTION
## Summary
- Ports the passing Auth0 compute instance access coverage into the Uni compute Go integration suite.
- Adds fixture-token fallbacks for admin, audit, and public-admin service tokens so the suite can consume the Uni fixture naming used by the Auth0 test run.
- Adds audit read-only instance listing coverage and public-admin/private-org isolation coverage.

## Auth0 source verification
- Passed before porting: `audit token should list instances (read-only)`.
- Passed before porting: `public-admin token should not have access to private org instances`.
- Not ported this iteration: `public org token querying private org instances should not return server_error`, because the Auth0 source test failed before porting with a 401 response.
- Excluded per porting review: invalid AI Proxy/direct-passport and multi-org `X-Organization-Id` cases.

## Testing
- `gofmt -w test/api/config.go test/api/suites/instance_operations_test.go`
- `go test -tags=integration ./test/api/... -run '^$'`
- `git diff --check`

@claude please review this draft PR, especially the fixture-token fallback names and the 403-or-empty-list assertion for public-admin access to private-org instances.