### PR TITLE
feat: propagate OTLP resource attributes

### DIFF
--- a/charts/compute/Chart.yaml
+++ b/charts/compute/Chart.yaml
@@ -11,5 +11,5 @@ icon: https://raw.githubusercontent.com/unikorn-cloud/assets/main/images/logos/d
 
 dependencies:
 - name: unikorn-common
-  version: 0.1.17
+  version: 0.1.18
   repository: https://nscaledev.github.io/uni-helm-common

--- a/charts/compute/templates/instance-controller/deployment.yaml
+++ b/charts/compute/templates/instance-controller/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- include "unikorn.region.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         {{- include "unikorn.mtls.flags" . | nindent 8 }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         ports:
         - name: prometheus
           containerPort: 8080

--- a/charts/compute/templates/server/deployment.yaml
+++ b/charts/compute/templates/server/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         {{- range $i, $arg := .Values.server.extraFlags }}
         - {{ $arg }}
         {{- end }}
+        {{- with include "unikorn.otlp.env" . }}
+        env:
+{{ . | indent 8 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 6080

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -93,6 +93,8 @@ region:
 # Sets the OTLP endpoint for shipping spans.
 # otlp:
 #   endpoint: jaeger-collector.default:4318
+#   resourceAttributes:
+#     deployment.environment: dev
 
 # Defines Prometheus monitoring integration.
 monitoring:

--- a/charts/compute/values.yaml
+++ b/charts/compute/values.yaml
@@ -91,10 +91,11 @@ region:
   host: region.unikorn-cloud.org
 
 # Sets the OTLP endpoint for shipping spans.
-# otlp:
-#   endpoint: jaeger-collector.default:4318
-#   resourceAttributes:
-#     deployment.environment: dev
+# global:
+#   otlp:
+#     endpoint: jaeger-collector.default:4318
+#     resourceAttributes:
+#       deployment.environment: <environment>
 
 # Defines Prometheus monitoring integration.
 monitoring:


### PR DESCRIPTION
## Summary

Bumps `unikorn-common` to `0.1.18` and wires the new OTLP resource attributes helper into the Compute deployments that already emit OTLP traces.

This renders `OTEL_RESOURCE_ATTRIBUTES` when `global.otlp.resourceAttributes` is configured, allowing spans to carry `deployment.environment` for Tempo spanmetrics promotion.

## Why

The Service Health & Error Rate dashboard is expected to support environment filtering for UNI, but the environment dropdown only shows `All` because UNI spanmetrics do not currently carry the `deployment_environment` label.

Tempo can promote `deployment.environment` into `deployment_environment`, but Compute pods first need that OTEL resource attribute on emitted spans.

Dashboard: https://observability-grafana.nscale.teleport.sh/d/uni-api-health/uni-api-health

## Dependency

Depends on `unikorn-common` `0.1.18` being released from:

- https://github.com/nscaledev/uni-helm-common/pull/17

## Validation

- Local render/lint against the local `unikorn-common` chart
- Verified default render does not include `OTEL_RESOURCE_ATTRIBUTES`
- Verified configured render includes 2 `OTEL_RESOURCE_ATTRIBUTES` entries
- `git diff --check`
- GitHub commit verification: signed and verified